### PR TITLE
Ticlv5: additional changes concerning timing and linking

### DIFF
--- a/DataFormats/HGCalReco/BuildFile.xml
+++ b/DataFormats/HGCalReco/BuildFile.xml
@@ -1,9 +1,12 @@
 <use name="DataFormats/Math"/>
 <use name="DataFormats/Provenance"/>
+<use name="DataFormats/Portable"/>
+<use name="DataFormats/SoATemplate"/>
 <use name="DataFormats/Candidate"/>
 <use name="DataFormats/Common"/>
 <use name="DataFormats/TrackReco"/>
 <use name="DataFormats/GeometryVector"/>
+<use name="HeterogeneousCore/AlpakaInterface"/>
 <use name="eigen"/>
 <export>
   <lib name="1"/>

--- a/DataFormats/HGCalReco/interface/MtdHostCollection.h
+++ b/DataFormats/HGCalReco/interface/MtdHostCollection.h
@@ -1,0 +1,12 @@
+#ifndef DataFormats_HGCalReco_MtdHostCollection_h
+#define DataFormats_HGCalReco_MtdHostCollection_h
+
+#include "DataFormats/Portable/interface/PortableHostCollection.h"
+#include "DataFormats/HGCalReco/interface/MtdSoA.h"
+
+// MtdSoA in host memory
+using MtdHostCollection = PortableHostCollection<MtdSoA>;
+using MtdHostCollectionView = PortableHostCollection<MtdSoA>::View;
+using MtdHostCollectionConstView = PortableHostCollection<MtdSoA>::ConstView;
+
+#endif

--- a/DataFormats/HGCalReco/interface/MtdSoA.h
+++ b/DataFormats/HGCalReco/interface/MtdSoA.h
@@ -1,0 +1,27 @@
+#ifndef DataFormats_HGCalReco_MtdSoA_h
+#define DataFormats_HGCalReco_MtdSoA_h
+
+#include "DataFormats/SoATemplate/interface/SoALayout.h"
+
+GENERATE_SOA_LAYOUT(MtdSoALayout,
+                    SOA_COLUMN(int32_t, trackAsocMTD),
+                    SOA_COLUMN(float, time0),
+                    SOA_COLUMN(float, time0Err),
+                    SOA_COLUMN(float, time),
+                    SOA_COLUMN(float, timeErr),
+                    SOA_COLUMN(float, MVAquality),
+                    SOA_COLUMN(float, pathLength),
+                    SOA_COLUMN(float, beta),
+                    SOA_COLUMN(float, posInMTD_x),
+                    SOA_COLUMN(float, posInMTD_y),
+                    SOA_COLUMN(float, posInMTD_z),
+                    SOA_COLUMN(float, momentumWithMTD),
+                    SOA_COLUMN(float, probPi),
+                    SOA_COLUMN(float, probK),
+                    SOA_COLUMN(float, probP))
+
+using MtdSoA = MtdSoALayout<>;
+using MtdSoAView = MtdSoA::View;
+using MtdSoAConstView = MtdSoA::ConstView;
+
+#endif

--- a/DataFormats/HGCalReco/interface/TICLCandidate.h
+++ b/DataFormats/HGCalReco/interface/TICLCandidate.h
@@ -24,10 +24,12 @@ public:
 
   TICLCandidate(const edm::Ptr<ticl::Trackster>& trackster)
       : LeafCandidate(),
-        idProbabilities_{},
         tracksters_({trackster}),
+        idProbabilities_{},
         time_(trackster->time()),
         timeError_(trackster->timeError()),
+        MTDtime_{0.f},
+        MTDtimeError_{-1.f},
         rawEnergy_(0.f) {}
 
   TICLCandidate(const edm::Ptr<reco::Track> trackPtr, const edm::Ptr<ticl::Trackster>& tracksterPtr)
@@ -79,8 +81,12 @@ public:
   inline float time() const { return time_; }
   inline float timeError() const { return timeError_; }
 
-  void setTime(float time) { time_ = time; };
-  void setTimeError(float timeError) { timeError_ = timeError; }
+  void setTime(float time, float timeError) { time_ = time; timeError_ = timeError;};
+
+  inline float MTDtime() const { return MTDtime_; }
+  inline float MTDtimeError() const { return MTDtimeError_; }
+
+  void setMTDTime(float time, float timeError) { MTDtime_ = time; MTDtimeError_ = timeError; };
 
   inline const edm::Ptr<reco::Track> trackPtr() const { return trackPtr_; }
   void setTrackPtr(const edm::Ptr<reco::Track>& trackPtr) { trackPtr_ = trackPtr; }
@@ -114,17 +120,18 @@ public:
   inline void setIdProbability(ParticleType type, float value) { idProbabilities_[int(type)] = value; }
 
 private:
-  std::array<float, 8> idProbabilities_;
+  // vector of Ptr so Tracksters can come from different collections
+  // and there can be derived classes
   std::vector<edm::Ptr<ticl::Trackster> > tracksters_;
   edm::Ptr<reco::Track> trackPtr_;
+  // Since it contains multiple tracksters, duplicate the probability interface
+  std::array<float, 8> idProbabilities_;
 
   float time_;
   float timeError_;
+  float MTDtime_;
+  float MTDtimeError_;
   float rawEnergy_;
 
-  // vector of Ptr so Tracksters can come from different collections
-  // and there can be derived classes
-
-  // Since it contains multiple tracksters, duplicate the probability interface
 };
 #endif

--- a/DataFormats/HGCalReco/interface/TICLCandidate.h
+++ b/DataFormats/HGCalReco/interface/TICLCandidate.h
@@ -38,7 +38,7 @@ public:
       edm::LogError("TICLCandidate") << "At least one between track and trackster must be valid\n";
 
     if (tracksterPtr.isNonnull()) {
-      tracksters_.push_back(std::move(tracksterPtr));
+      tracksters_.push_back(tracksterPtr);
       auto const& trackster = tracksters_[0].get();
       idProbabilities_ = trackster->id_probabilities();
       if (trackPtr_.isNonnull()) {
@@ -81,12 +81,18 @@ public:
   inline float time() const { return time_; }
   inline float timeError() const { return timeError_; }
 
-  void setTime(float time, float timeError) { time_ = time; timeError_ = timeError;};
+  void setTime(float time, float timeError) {
+    time_ = time;
+    timeError_ = timeError;
+  };
 
   inline float MTDtime() const { return MTDtime_; }
   inline float MTDtimeError() const { return MTDtimeError_; }
 
-  void setMTDTime(float time, float timeError) { MTDtime_ = time; MTDtimeError_ = timeError; };
+  void setMTDTime(float time, float timeError) {
+    MTDtime_ = time;
+    MTDtimeError_ = timeError;
+  };
 
   inline const edm::Ptr<reco::Track> trackPtr() const { return trackPtr_; }
   void setTrackPtr(const edm::Ptr<reco::Track>& trackPtr) { trackPtr_ = trackPtr; }
@@ -132,6 +138,5 @@ private:
   float MTDtime_;
   float MTDtimeError_;
   float rawEnergy_;
-
 };
 #endif

--- a/DataFormats/HGCalReco/interface/Trackster.h
+++ b/DataFormats/HGCalReco/interface/Trackster.h
@@ -40,8 +40,8 @@ namespace ticl {
         : barycenter_({0.f, 0.f, 0.f}),
           regressed_energy_(0.f),
           raw_energy_(0.f),
-          time_(0.f),
           boundTime_(0.f),
+          time_(0.f),
           timeError_(-1.f),
           id_probabilities_{},
           raw_pt_(0.f),
@@ -176,8 +176,8 @@ namespace ticl {
     float regressed_energy_;
     float raw_energy_;
     // -99, -1 if not available. ns units otherwise
-    float time_;
     float boundTime_;
+    float time_;
     float timeError_;
 
     // trackster ID probabilities

--- a/DataFormats/HGCalReco/src/classes.h
+++ b/DataFormats/HGCalReco/src/classes.h
@@ -1,5 +1,7 @@
 #include <vector>
 #include <array>
+#include "DataFormats/HGCalReco/interface/MtdSoA.h"
+#include "DataFormats/HGCalReco/interface/MtdHostCollection.h"
 #include "DataFormats/HGCalReco/interface/Trackster.h"
 #include "DataFormats/HGCalReco/interface/TICLLayerTile.h"
 #include "DataFormats/HGCalReco/interface/TICLSeedingRegion.h"

--- a/DataFormats/HGCalReco/src/classes_def.xml
+++ b/DataFormats/HGCalReco/src/classes_def.xml
@@ -59,4 +59,22 @@
   <class name="std::vector<TICLCandidate>" />
   <class name="edm::Wrapper<TICLCandidate>" />
   <class name="edm::Wrapper<std::vector<TICLCandidate> >" />
+
+  <class name="MtdSoA"/>
+  <class name="MtdSoA::View"/>
+
+  <class name="MtdHostCollection"/>
+  <read
+    sourceClass="MtdHostCollection"
+    targetClass="MtdHostCollection"
+    version="[1-]"
+    source="MtdSoA layout_;"
+    target="buffer_,layout_,view_"
+    embed="false">
+  <![CDATA[
+    MtdHostCollection::ROOTReadStreamer(newObj, onfile.layout_);
+  ]]>
+  </read>
+  <class name="edm::Wrapper<MtdHostCollection>" splitLevel="0"/> 
+
 </lcgdict>

--- a/DataFormats/HGCalReco/src/classes_def.xml
+++ b/DataFormats/HGCalReco/src/classes_def.xml
@@ -1,6 +1,7 @@
 
 <lcgdict>
-  <class name="ticl::Trackster" ClassVersion="11">
+  <class name="ticl::Trackster" ClassVersion="12">
+    <version ClassVersion="12" checksum="2111726404"/>
     <version ClassVersion="11" checksum="2995118904"/>
     <version ClassVersion="10" checksum="556627704"/>
     <version ClassVersion="9" checksum="1001808235"/>
@@ -52,7 +53,8 @@
   <class name="edm::Wrapper<TICLSeedingRegion>" />
   <class name="edm::Wrapper<std::vector<TICLSeedingRegion> >" />
 
-  <class name="TICLCandidate" ClassVersion="4">
+  <class name="TICLCandidate" ClassVersion="5">
+   <version ClassVersion="5" checksum="2260471800"/>
    <version ClassVersion="4" checksum="3155265136"/>
    <version ClassVersion="3" checksum="450468662"/>
   </class>

--- a/HLTrigger/Configuration/python/HLT_75e33/modules/pfTICL_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/modules/pfTICL_cfi.py
@@ -26,4 +26,10 @@ pfTICL = cms.EDProducer("PFTICLProducer",
         trackQuality = cms.string('highPurity')
     ),
     ticlCandidateSrc = cms.InputTag("ticlTrackstersMerge"),
+    timingQualityThreshold = cms.double(0.5),
+    trackTimeErrorMap = cms.InputTag("tofPID","sigmat0"),
+    trackTimeQualityMap = cms.InputTag("mtdTrackQualityMVA","mtdQualMVA"),
+    trackTimeValueMap = cms.InputTag("tofPID","t0"),
+    useMTDTiming = cms.bool(False),
+    useTimingAverage = cms.bool(False)
 )

--- a/HLTrigger/Configuration/python/HLT_75e33/modules/pfTICL_cfi.py
+++ b/HLTrigger/Configuration/python/HLT_75e33/modules/pfTICL_cfi.py
@@ -26,10 +26,4 @@ pfTICL = cms.EDProducer("PFTICLProducer",
         trackQuality = cms.string('highPurity')
     ),
     ticlCandidateSrc = cms.InputTag("ticlTrackstersMerge"),
-    timingQualityThreshold = cms.double(0.5),
-    trackTimeErrorMap = cms.InputTag("tofPID","sigmat0"),
-    trackTimeQualityMap = cms.InputTag("mtdTrackQualityMVA","mtdQualMVA"),
-    trackTimeValueMap = cms.InputTag("tofPID","t0"),
-    useMTDTiming = cms.bool(False),
-    useTimingAverage = cms.bool(False)
 )

--- a/RecoHGCal/TICL/interface/TICLInterpretationAlgoBase.h
+++ b/RecoHGCal/TICL/interface/TICLInterpretationAlgoBase.h
@@ -65,16 +65,18 @@ namespace ticl {
     struct TrackTimingInformation {
       const edm::Handle<edm::ValueMap<float>> tkTime_h;
       const edm::Handle<edm::ValueMap<float>> tkTimeErr_h;
+      const edm::Handle<edm::ValueMap<float>> tkQuality_h;
       const edm::Handle<edm::ValueMap<float>> tkBeta_h;
       const edm::Handle<edm::ValueMap<float>> tkPath_h;
       const edm::Handle<edm::ValueMap<GlobalPoint>> tkMtdPos_h;
 
       TrackTimingInformation(const edm::Handle<edm::ValueMap<float>> tkT,
                              const edm::Handle<edm::ValueMap<float>> tkTE,
+                             const edm::Handle<edm::ValueMap<float>> tkQ,
                              const edm::Handle<edm::ValueMap<float>> tkB,
                              const edm::Handle<edm::ValueMap<float>> tkP,
                              const edm::Handle<edm::ValueMap<GlobalPoint>> mtdPos)
-          : tkTime_h(tkT), tkTimeErr_h(tkTE), tkBeta_h(tkB), tkPath_h(tkP), tkMtdPos_h(mtdPos) {}
+          : tkTime_h(tkT), tkTimeErr_h(tkTE), tkQuality_h(tkQ), tkBeta_h(tkB), tkPath_h(tkP), tkMtdPos_h(mtdPos) {}
     };
 
     virtual void makeCandidates(const Inputs& input,

--- a/RecoHGCal/TICL/interface/TICLInterpretationAlgoBase.h
+++ b/RecoHGCal/TICL/interface/TICLInterpretationAlgoBase.h
@@ -4,6 +4,7 @@
 #include <memory>
 #include <vector>
 #include "DataFormats/CaloRecHit/interface/CaloCluster.h"
+#include "DataFormats/HGCalReco/interface/MtdHostCollection.h"
 #include "DataFormats/HGCalReco/interface/Trackster.h"
 #include "DataFormats/HGCalReco/interface/TICLCandidate.h"
 #include "DataFormats/HGCalReco/interface/TICLLayerTile.h"
@@ -80,7 +81,7 @@ namespace ticl {
     };
 
     virtual void makeCandidates(const Inputs& input,
-                                const TrackTimingInformation& inputTiming,
+                                edm::Handle<MtdHostCollection> inputTiming_h,
                                 std::vector<Trackster>& resultTracksters,
                                 std::vector<int>& resultCandidate) = 0;
 

--- a/RecoHGCal/TICL/plugins/GeneralInterpretationAlgo.cc
+++ b/RecoHGCal/TICL/plugins/GeneralInterpretationAlgo.cc
@@ -324,12 +324,13 @@ void GeneralInterpretationAlgo::makeCandidates(const Inputs &input,
     float track_beta = 0.f;
     GlobalPoint track_MtdPos{0.f, 0.f, 0.f};
     if (useMTDTiming) {
-      auto const& inputTimingView = (*inputTiming_h).const_view();
+      auto const &inputTimingView = (*inputTiming_h).const_view();
       track_time = inputTimingView.time()[i];
       track_timeErr = inputTimingView.timeErr()[i];
       track_quality = inputTimingView.MVAquality()[i];
       track_beta = inputTimingView.beta()[i];
-      track_MtdPos = {inputTimingView.posInMTD_x()[i], inputTimingView.posInMTD_y()[i], inputTimingView.posInMTD_z()[i]};
+      track_MtdPos = {
+          inputTimingView.posInMTD_x()[i], inputTimingView.posInMTD_y()[i], inputTimingView.posInMTD_z()[i]};
     }
 
     for (auto const tsIdx : tsNearTk[i]) {

--- a/RecoHGCal/TICL/plugins/GeneralInterpretationAlgo.cc
+++ b/RecoHGCal/TICL/plugins/GeneralInterpretationAlgo.cc
@@ -203,10 +203,10 @@ bool GeneralInterpretationAlgo::timeAndEnergyCompatible(float &total_raw_energy,
 }
 
 void GeneralInterpretationAlgo::makeCandidates(const Inputs &input,
-                                               const TrackTimingInformation &inputTiming,
+                                               edm::Handle<MtdHostCollection> inputTiming_h,
                                                std::vector<Trackster> &resultTracksters,
                                                std::vector<int> &resultCandidate) {
-  bool useMTDTiming = inputTiming.tkTime_h.isValid();
+  bool useMTDTiming = inputTiming_h.isValid();
   std::cout << "GeneralInterpretationAlgo " << std::endl;
   const auto tkH = input.tracksHandle;
   const auto maskTracks = input.maskedTracks;
@@ -318,18 +318,18 @@ void GeneralInterpretationAlgo::makeCandidates(const Inputs &input,
     std::vector<unsigned int> chargedCandidate;
     float total_raw_energy = 0.f;
 
-    auto tkRef = reco::TrackRef(tkH, i);
     float track_time = 0.f;
     float track_timeErr = 0.f;
     float track_quality = 0.f;
     float track_beta = 0.f;
     GlobalPoint track_MtdPos{0.f, 0.f, 0.f};
     if (useMTDTiming) {
-      track_time = (*inputTiming.tkTime_h)[tkRef];
-      track_timeErr = (*inputTiming.tkTimeErr_h)[tkRef];
-      track_quality = (*inputTiming.tkQuality_h)[tkRef];
-      track_beta = (*inputTiming.tkBeta_h)[tkRef];
-      track_MtdPos = (*inputTiming.tkMtdPos_h)[tkRef];
+      auto const& inputTimingView = (*inputTiming_h).const_view();
+      track_time = inputTimingView.time()[i];
+      track_timeErr = inputTimingView.timeErr()[i];
+      track_quality = inputTimingView.MVAquality()[i];
+      track_beta = inputTimingView.beta()[i];
+      track_MtdPos = {inputTimingView.posInMTD_x()[i], inputTimingView.posInMTD_y()[i], inputTimingView.posInMTD_z()[i]};
     }
 
     for (auto const tsIdx : tsNearTk[i]) {

--- a/RecoHGCal/TICL/plugins/GeneralInterpretationAlgo.cc
+++ b/RecoHGCal/TICL/plugins/GeneralInterpretationAlgo.cc
@@ -295,11 +295,12 @@ void GeneralInterpretationAlgo::makeCandidates(const Inputs &input,
 
   }  // TS
 
+  // step 1: tracks -> all tracksters, at firstLayerEE
   std::vector<std::vector<unsigned>> tsNearTk(tracks.size());
   findTrackstersInWindow(
       tracksters, trackPColl, tracksterPropTiles, tsAllProp, del_tk_ts_layer1_, tracksters.size(), tsNearTk);
-  // step 4: tracks -> all tracksters, at lastLayerEE
 
+  // step 2: tracks -> all tracksters, at lastLayerEE
   std::vector<std::vector<unsigned>> tsNearTkAtInt(tracks.size());
   findTrackstersInWindow(
       tracksters, tkPropIntColl, tsPropIntTiles, tsAllPropInt, del_tk_ts_int_, tracksters.size(), tsNearTkAtInt);

--- a/RecoHGCal/TICL/plugins/GeneralInterpretationAlgo.h
+++ b/RecoHGCal/TICL/plugins/GeneralInterpretationAlgo.h
@@ -18,7 +18,7 @@ namespace ticl {
     ~GeneralInterpretationAlgo() override;
 
     void makeCandidates(const Inputs &input,
-                        const TrackTimingInformation &inputTiming,
+                        edm::Handle<MtdHostCollection> inputTiming_h,
                         std::vector<Trackster> &resultTracksters,
                         std::vector<int> &resultCandidate) override;
 

--- a/RecoHGCal/TICL/plugins/GeneralInterpretationAlgo.h
+++ b/RecoHGCal/TICL/plugins/GeneralInterpretationAlgo.h
@@ -51,6 +51,7 @@ namespace ticl {
                                  const Trackster &trackster,
                                  const float &tkTime,
                                  const float &tkTimeErr,
+                                 const float &tkQual,
                                  const float &tkBeta,
                                  const GlobalPoint &tkMtdPos,
                                  bool useMTDTiming);
@@ -59,8 +60,7 @@ namespace ticl {
     const float maxDeltaT_ = 3.0f;
     const float del_tk_ts_layer1_;
     const float del_tk_ts_int_;
-    const float del_ts_em_had_;
-    const float del_ts_had_had_;
+    const float timing_quality_threshold_;
 
     const HGCalDDDConstants *hgcons_;
 

--- a/RecoHGCal/TICL/plugins/MTDSoAProducer.cc
+++ b/RecoHGCal/TICL/plugins/MTDSoAProducer.cc
@@ -1,0 +1,154 @@
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "HeterogeneousCore/AlpakaInterface/interface/host.h"
+
+#include "DataFormats/Common/interface/ValueMap.h"
+#include "DataFormats/HGCalReco/interface/MtdHostCollection.h"
+#include "DataFormats/TrackReco/interface/TrackFwd.h"
+#include "DataFormats/TrackReco/interface/Track.h"
+//#include "DataFormats/TrackReco/interface/TrackBase.h"
+
+using namespace edm;
+
+class MTDSoAProducer : public edm::stream::EDProducer<> {
+public:
+  MTDSoAProducer(const ParameterSet& pset);
+
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+
+  void produce(edm::Event& ev, const edm::EventSetup& es) final;
+
+private:
+  edm::EDGetTokenT<reco::TrackCollection> tracksToken_;
+  edm::EDGetTokenT<edm::ValueMap<int>> trackAssocToken_;
+  edm::EDGetTokenT<edm::ValueMap<float>> t0Token_;
+  edm::EDGetTokenT<edm::ValueMap<float>> sigmat0Token_;
+  edm::EDGetTokenT<edm::ValueMap<float>> tmtdToken_;
+  edm::EDGetTokenT<edm::ValueMap<float>> sigmatmtdToken_;
+  edm::EDGetTokenT<edm::ValueMap<float>> betaToken_;
+  edm::EDGetTokenT<edm::ValueMap<float>> pathToken_;
+  edm::EDGetTokenT<edm::ValueMap<float>> MVAQualityToken_;
+  edm::EDGetTokenT<edm::ValueMap<GlobalPoint>> posInMtdToken_;
+  edm::EDGetTokenT<edm::ValueMap<float>> momentumWithMTDToken_;
+  edm::EDGetTokenT<edm::ValueMap<float>> probPiToken_;
+  edm::EDGetTokenT<edm::ValueMap<float>> probKToken_;
+  edm::EDGetTokenT<edm::ValueMap<float>> probPToken_;
+};
+
+MTDSoAProducer::MTDSoAProducer(const ParameterSet& iConfig)
+    : tracksToken_(consumes<reco::TrackCollection>(iConfig.getParameter<edm::InputTag>("tracksSrc"))),
+      trackAssocToken_(consumes<edm::ValueMap<int>>(iConfig.getParameter<edm::InputTag>("trackAssocSrc"))),
+      t0Token_(consumes<edm::ValueMap<float>>(iConfig.getParameter<edm::InputTag>("t0Src"))),
+      sigmat0Token_(consumes<edm::ValueMap<float>>(iConfig.getParameter<edm::InputTag>("sigmat0Src"))),
+      tmtdToken_(consumes<edm::ValueMap<float>>(iConfig.getParameter<edm::InputTag>("tmtdSrc"))),
+      sigmatmtdToken_(consumes<edm::ValueMap<float>>(iConfig.getParameter<edm::InputTag>("sigmatmtdSrc"))),
+      betaToken_(consumes<edm::ValueMap<float>>(iConfig.getParameter<edm::InputTag>("betamtd"))),
+      pathToken_(consumes<edm::ValueMap<float>>(iConfig.getParameter<edm::InputTag>("pathmtd"))),
+      MVAQualityToken_(consumes<edm::ValueMap<float>>(iConfig.getParameter<edm::InputTag>("mvaquality"))),
+      posInMtdToken_(consumes<edm::ValueMap<GlobalPoint>>(iConfig.getParameter<edm::InputTag>("posmtd"))),
+      momentumWithMTDToken_(consumes<edm::ValueMap<float>>(iConfig.getParameter<edm::InputTag>("momentum"))),
+      probPiToken_(consumes<edm::ValueMap<float>>(iConfig.getParameter<edm::InputTag>("probPi"))),
+      probKToken_(consumes<edm::ValueMap<float>>(iConfig.getParameter<edm::InputTag>("probK"))),
+      probPToken_(consumes<edm::ValueMap<float>>(iConfig.getParameter<edm::InputTag>("probP"))) {
+  produces<MtdHostCollection>();
+}
+
+// Configuration descriptions
+void MTDSoAProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  edm::ParameterSetDescription desc;
+  desc.add<edm::InputTag>("tracksSrc", edm::InputTag("generalTracks"));
+  desc.add<edm::InputTag>("trackAssocSrc", edm::InputTag("trackExtenderWithMTD:generalTrackassoc"));
+  desc.add<edm::InputTag>("t0Src", edm::InputTag("tofPID:t0"));
+  desc.add<edm::InputTag>("sigmat0Src", edm::InputTag("tofPID:sigmat0"));
+  desc.add<edm::InputTag>("tmtdSrc", edm::InputTag("trackExtenderWithMTD:generalTracktmtd"));
+  desc.add<edm::InputTag>("sigmatmtdSrc", edm::InputTag("trackExtenderWithMTD:generalTracksigmatmtd"));
+  desc.add<edm::InputTag>("betamtd", edm::InputTag("trackExtenderWithMTD:generalTrackBeta"));
+  desc.add<edm::InputTag>("pathmtd", edm::InputTag("trackExtenderWithMTD:generalTrackPathLength"));
+  desc.add<edm::InputTag>("mvaquality", edm::InputTag("mtdTrackQualityMVA:mtdQualMVA"));
+  desc.add<edm::InputTag>("posmtd", edm::InputTag("trackExtenderWithMTD:generalTrackmtdpos"));
+  desc.add<edm::InputTag>("momentum", edm::InputTag("trackExtenderWithMTD:generalTrackp"));
+  desc.add<edm::InputTag>("probPi", edm::InputTag("tofPID:probPi"));
+  desc.add<edm::InputTag>("probK", edm::InputTag("tofPID:probK"));
+  desc.add<edm::InputTag>("probP", edm::InputTag("tofPID:probP"));
+
+  descriptions.add("mtdSoAProducer", desc);
+}
+
+void MTDSoAProducer::produce(edm::Event& ev, const edm::EventSetup& es) {
+
+  edm::Handle<reco::TrackCollection> tracksH;
+  ev.getByToken(tracksToken_, tracksH);
+  const auto& tracks = *tracksH;
+
+  const auto& trackAssoc = ev.get(trackAssocToken_);
+
+  const auto& t0 = ev.get(t0Token_);
+  const auto& sigmat0 = ev.get(sigmat0Token_);
+
+  const auto& tmtd = ev.get(tmtdToken_);
+  const auto& sigmatmtd = ev.get(sigmatmtdToken_);
+
+  const auto& beta = ev.get(betaToken_);
+  const auto& path = ev.get(pathToken_);
+  const auto& MVAquality = ev.get(MVAQualityToken_);
+  const auto& posInMTD = ev.get(posInMtdToken_);
+  const auto& momentum = ev.get(momentumWithMTDToken_);
+  const auto& probPi = ev.get(probPiToken_);
+  const auto& probK = ev.get(probKToken_);
+  const auto& probP = ev.get(probPToken_);
+
+  auto MtdInfo = std::make_unique<MtdHostCollection>(tracks.size(), cms::alpakatools::host());
+
+  auto& MtdInfoView = MtdInfo->view();
+  for (unsigned int iTrack = 0; iTrack < tracks.size(); ++iTrack) {
+    const reco::TrackRef trackref(tracksH, iTrack);
+
+    if (trackAssoc[trackref] == -1) {
+      MtdInfoView.trackAsocMTD()[iTrack] = -1;
+      MtdInfoView.time0()[iTrack] = 0.f;
+      MtdInfoView.time0Err()[iTrack] = -1.f;
+      MtdInfoView.time()[iTrack] = 0.f;
+      MtdInfoView.timeErr()[iTrack] = -1.f;
+      MtdInfoView.MVAquality()[iTrack] = 0.f;
+      MtdInfoView.pathLength()[iTrack] = 0.f;
+      MtdInfoView.beta()[iTrack] = 0.f;
+      MtdInfoView.posInMTD_x()[iTrack] = 0.f;
+      MtdInfoView.posInMTD_y()[iTrack] = 0.f;
+      MtdInfoView.posInMTD_z()[iTrack] = 0.f;
+      MtdInfoView.momentumWithMTD()[iTrack] = 0.f;
+      MtdInfoView.probPi()[iTrack] = 0.f;
+      MtdInfoView.probK()[iTrack] = 0.f;
+      MtdInfoView.probP()[iTrack] = 0.f;
+      continue;
+    }
+
+    MtdInfoView.trackAsocMTD()[iTrack] = trackAssoc[trackref];
+    MtdInfoView.time0()[iTrack] = t0[trackref];
+    MtdInfoView.time0Err()[iTrack] = sigmat0[trackref];
+    MtdInfoView.time()[iTrack] = tmtd[trackref];
+    MtdInfoView.timeErr()[iTrack] = sigmatmtd[trackref];
+    MtdInfoView.MVAquality()[iTrack] = MVAquality[trackref];
+    MtdInfoView.pathLength()[iTrack] = path[trackref];
+    MtdInfoView.beta()[iTrack] = beta[trackref];
+    MtdInfoView.posInMTD_x()[iTrack] = posInMTD[trackref].x();
+    MtdInfoView.posInMTD_y()[iTrack] = posInMTD[trackref].y();
+    MtdInfoView.posInMTD_z()[iTrack] = posInMTD[trackref].z();
+    MtdInfoView.momentumWithMTD()[iTrack] = momentum[trackref];
+    MtdInfoView.probPi()[iTrack] = probPi[trackref];
+    MtdInfoView.probK()[iTrack] = probK[trackref];
+    MtdInfoView.probP()[iTrack] = probP[trackref];
+
+  }
+
+  ev.put(std::move(MtdInfo));
+
+}
+
+//define this as a plug-in
+#include <FWCore/Framework/interface/MakerMacros.h>
+DEFINE_FWK_MODULE(MTDSoAProducer);

--- a/RecoHGCal/TICL/plugins/MTDSoAProducer.cc
+++ b/RecoHGCal/TICL/plugins/MTDSoAProducer.cc
@@ -80,7 +80,6 @@ void MTDSoAProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptio
 }
 
 void MTDSoAProducer::produce(edm::Event& ev, const edm::EventSetup& es) {
-
   edm::Handle<reco::TrackCollection> tracksH;
   ev.getByToken(tracksToken_, tracksH);
   const auto& tracks = *tracksH;
@@ -142,11 +141,9 @@ void MTDSoAProducer::produce(edm::Event& ev, const edm::EventSetup& es) {
     MtdInfoView.probPi()[iTrack] = probPi[trackref];
     MtdInfoView.probK()[iTrack] = probK[trackref];
     MtdInfoView.probP()[iTrack] = probP[trackref];
-
   }
 
   ev.put(std::move(MtdInfo));
-
 }
 
 //define this as a plug-in

--- a/RecoHGCal/TICL/plugins/PFTICLProducer.cc
+++ b/RecoHGCal/TICL/plugins/PFTICLProducer.cc
@@ -26,13 +26,9 @@ public:
 
 private:
   // parameters
-  const bool useMTDTiming_;
-  const bool useTimingAverage_;
-  const float timingQualityThreshold_;
   const bool energy_from_regression_;
   // inputs
   const edm::EDGetTokenT<edm::View<TICLCandidate>> ticl_candidates_;
-  const edm::EDGetTokenT<edm::ValueMap<float>> srcTrackTime_, srcTrackTimeError_, srcTrackTimeQuality_;
   const edm::EDGetTokenT<reco::MuonCollection> muons_;
   // For PFMuonAlgo
   std::unique_ptr<PFMuonAlgo> pfmu_;
@@ -41,14 +37,8 @@ private:
 DEFINE_FWK_MODULE(PFTICLProducer);
 
 PFTICLProducer::PFTICLProducer(const edm::ParameterSet& conf)
-    : useMTDTiming_(conf.getParameter<bool>("useMTDTiming")),
-      useTimingAverage_(conf.getParameter<bool>("useTimingAverage")),
-      timingQualityThreshold_(conf.getParameter<double>("timingQualityThreshold")),
-      energy_from_regression_(conf.getParameter<bool>("energyFromRegression")),
+    : energy_from_regression_(conf.getParameter<bool>("energyFromRegression")),
       ticl_candidates_(consumes<edm::View<TICLCandidate>>(conf.getParameter<edm::InputTag>("ticlCandidateSrc"))),
-      srcTrackTime_(consumes<edm::ValueMap<float>>(conf.getParameter<edm::InputTag>("trackTimeValueMap"))),
-      srcTrackTimeError_(consumes<edm::ValueMap<float>>(conf.getParameter<edm::InputTag>("trackTimeErrorMap"))),
-      srcTrackTimeQuality_(consumes<edm::ValueMap<float>>(conf.getParameter<edm::InputTag>("trackTimeQualityMap"))),
       muons_(consumes<reco::MuonCollection>(conf.getParameter<edm::InputTag>("muonSrc"))),
       pfmu_(std::make_unique<PFMuonAlgo>(conf.getParameterSet("pfMuonAlgoParameters"),
                                          false)) {  // postMuonCleaning = false
@@ -58,13 +48,7 @@ PFTICLProducer::PFTICLProducer(const edm::ParameterSet& conf)
 void PFTICLProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   edm::ParameterSetDescription desc;
   desc.add<edm::InputTag>("ticlCandidateSrc", edm::InputTag("ticlTrackstersMerge"));
-  desc.add<edm::InputTag>("trackTimeValueMap", edm::InputTag("tofPID:t0"));
-  desc.add<edm::InputTag>("trackTimeErrorMap", edm::InputTag("tofPID:sigmat0"));
-  desc.add<edm::InputTag>("trackTimeQualityMap", edm::InputTag("mtdTrackQualityMVA:mtdQualMVA"));
   desc.add<bool>("energyFromRegression", true);
-  desc.add<double>("timingQualityThreshold", 0.5);
-  desc.add<bool>("useMTDTiming", true);
-  desc.add<bool>("useTimingAverage", false);
   // For PFMuonAlgo
   desc.add<edm::InputTag>("muonSrc", edm::InputTag("muons1stStep"));
   edm::ParameterSetDescription psd_PFMuonAlgo;
@@ -79,10 +63,6 @@ void PFTICLProducer::produce(edm::Event& evt, const edm::EventSetup& es) {
   edm::Handle<edm::View<TICLCandidate>> ticl_cand_h;
   evt.getByToken(ticl_candidates_, ticl_cand_h);
   const auto ticl_candidates = *ticl_cand_h;
-  edm::Handle<edm::ValueMap<float>> trackTimeH, trackTimeErrH, trackTimeQualH;
-  evt.getByToken(srcTrackTime_, trackTimeH);
-  evt.getByToken(srcTrackTimeError_, trackTimeErrH);
-  evt.getByToken(srcTrackTimeQuality_, trackTimeQualH);
   const auto muonH = evt.getHandle(muons_);
   const auto& muons = *muonH;
 
@@ -146,37 +126,7 @@ void PFTICLProducer::produce(edm::Event& evt, const edm::EventSetup& es) {
         pfmu_->reconstructMuon(candidate, muonref, allowLoose);
       }
     }
-
-    // HGCAL timing as default values
-    auto time = ticl_cand.time();
-    auto timeE = ticl_cand.timeError();
-
-    if (useMTDTiming_ and candidate.charge()) {
-      // Ignore HGCAL timing until it will be TOF corrected
-      time = -99.;
-      timeE = -1.;
-      // Check MTD timing availability
-      const bool assocQuality = (*trackTimeQualH)[candidate.trackRef()] > timingQualityThreshold_;
-      if (assocQuality) {
-        const auto timeHGC = time;
-        const auto timeEHGC = timeE;
-        const auto timeMTD = (*trackTimeH)[candidate.trackRef()];
-        const auto timeEMTD = (*trackTimeErrH)[candidate.trackRef()];
-
-        if (useTimingAverage_ && (timeEMTD > 0 && timeEHGC > 0)) {
-          // Compute weighted average between HGCAL and MTD timing
-          const auto invTimeESqHGC = pow(timeEHGC, -2);
-          const auto invTimeESqMTD = pow(timeEMTD, -2);
-          timeE = 1.f / (invTimeESqHGC + invTimeESqMTD);
-          time = (timeHGC * invTimeESqHGC + timeMTD * invTimeESqMTD) * timeE;
-          timeE = sqrt(timeE);
-        } else if (timeEMTD > 0) {  // Ignore HGCal timing until it will be TOF corrected
-          time = timeMTD;
-          timeE = timeEMTD;
-        }
-      }
-    }
-    candidate.setTime(time, timeE);
+    candidate.setTime(ticl_cand.time(), ticl_cand.timeError());
   }
 
   evt.put(std::move(candidates));

--- a/RecoHGCal/TICL/plugins/PFTICLProducerV5.cc
+++ b/RecoHGCal/TICL/plugins/PFTICLProducerV5.cc
@@ -15,10 +15,10 @@
 
 #include "RecoParticleFlow/PFProducer/interface/PFMuonAlgo.h"
 
-class PFTICLProducer : public edm::stream::EDProducer<> {
+class PFTICLProducerV5 : public edm::stream::EDProducer<> {
 public:
-  PFTICLProducer(const edm::ParameterSet&);
-  ~PFTICLProducer() override {}
+  PFTICLProducerV5(const edm::ParameterSet&);
+  ~PFTICLProducerV5() override {}
 
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
@@ -26,63 +26,43 @@ public:
 
 private:
   // parameters
-  const bool useMTDTiming_;
-  const bool useTimingAverage_;
-  const float timingQualityThreshold_;
   const bool energy_from_regression_;
   // inputs
   const edm::EDGetTokenT<edm::View<TICLCandidate>> ticl_candidates_;
-  const edm::EDGetTokenT<edm::ValueMap<float>> srcTrackTime_, srcTrackTimeError_, srcTrackTimeQuality_;
   const edm::EDGetTokenT<reco::MuonCollection> muons_;
   // For PFMuonAlgo
   std::unique_ptr<PFMuonAlgo> pfmu_;
 };
 
-DEFINE_FWK_MODULE(PFTICLProducer);
+DEFINE_FWK_MODULE(PFTICLProducerV5);
 
-PFTICLProducer::PFTICLProducer(const edm::ParameterSet& conf)
-    : useMTDTiming_(conf.getParameter<bool>("useMTDTiming")),
-      useTimingAverage_(conf.getParameter<bool>("useTimingAverage")),
-      timingQualityThreshold_(conf.getParameter<double>("timingQualityThreshold")),
-      energy_from_regression_(conf.getParameter<bool>("energyFromRegression")),
+PFTICLProducerV5::PFTICLProducerV5(const edm::ParameterSet& conf)
+    : energy_from_regression_(conf.getParameter<bool>("energyFromRegression")),
       ticl_candidates_(consumes<edm::View<TICLCandidate>>(conf.getParameter<edm::InputTag>("ticlCandidateSrc"))),
-      srcTrackTime_(consumes<edm::ValueMap<float>>(conf.getParameter<edm::InputTag>("trackTimeValueMap"))),
-      srcTrackTimeError_(consumes<edm::ValueMap<float>>(conf.getParameter<edm::InputTag>("trackTimeErrorMap"))),
-      srcTrackTimeQuality_(consumes<edm::ValueMap<float>>(conf.getParameter<edm::InputTag>("trackTimeQualityMap"))),
       muons_(consumes<reco::MuonCollection>(conf.getParameter<edm::InputTag>("muonSrc"))),
       pfmu_(std::make_unique<PFMuonAlgo>(conf.getParameterSet("pfMuonAlgoParameters"),
                                          false)) {  // postMuonCleaning = false
   produces<reco::PFCandidateCollection>();
 }
 
-void PFTICLProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+void PFTICLProducerV5::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   edm::ParameterSetDescription desc;
-  desc.add<edm::InputTag>("ticlCandidateSrc", edm::InputTag("ticlTrackstersMerge"));
-  desc.add<edm::InputTag>("trackTimeValueMap", edm::InputTag("tofPID:t0"));
-  desc.add<edm::InputTag>("trackTimeErrorMap", edm::InputTag("tofPID:sigmat0"));
-  desc.add<edm::InputTag>("trackTimeQualityMap", edm::InputTag("mtdTrackQualityMVA:mtdQualMVA"));
+  desc.add<edm::InputTag>("ticlCandidateSrc", edm::InputTag("ticlCandidate"));
   desc.add<bool>("energyFromRegression", true);
-  desc.add<double>("timingQualityThreshold", 0.5);
-  desc.add<bool>("useMTDTiming", true);
-  desc.add<bool>("useTimingAverage", false);
   // For PFMuonAlgo
   desc.add<edm::InputTag>("muonSrc", edm::InputTag("muons1stStep"));
   edm::ParameterSetDescription psd_PFMuonAlgo;
   PFMuonAlgo::fillPSetDescription(psd_PFMuonAlgo);
   desc.add<edm::ParameterSetDescription>("pfMuonAlgoParameters", psd_PFMuonAlgo);
   //
-  descriptions.add("pfTICLProducer", desc);
+  descriptions.add("pfTICLProducerV5", desc);
 }
 
-void PFTICLProducer::produce(edm::Event& evt, const edm::EventSetup& es) {
+void PFTICLProducerV5::produce(edm::Event& evt, const edm::EventSetup& es) {
   //get TICLCandidates
   edm::Handle<edm::View<TICLCandidate>> ticl_cand_h;
   evt.getByToken(ticl_candidates_, ticl_cand_h);
   const auto ticl_candidates = *ticl_cand_h;
-  edm::Handle<edm::ValueMap<float>> trackTimeH, trackTimeErrH, trackTimeQualH;
-  evt.getByToken(srcTrackTime_, trackTimeH);
-  evt.getByToken(srcTrackTimeError_, trackTimeErrH);
-  evt.getByToken(srcTrackTimeQuality_, trackTimeQualH);
   const auto muonH = evt.getHandle(muons_);
   const auto& muons = *muonH;
 
@@ -141,42 +121,15 @@ void PFTICLProducer::produce(edm::Event& evt, const edm::EventSetup& es) {
       const int muId = PFMuonAlgo::muAssocToTrack(trackref, muons);
       if (muId != -1) {
         const reco::MuonRef muonref = reco::MuonRef(muonH, muId);
-        const bool allowLoose = (part_type == reco::PFCandidate::mu);
-        // Redefine pfmuon candidate kinematics and add muonref
-        pfmu_->reconstructMuon(candidate, muonref, allowLoose);
-      }
-    }
-
-    // HGCAL timing as default values
-    auto time = ticl_cand.time();
-    auto timeE = ticl_cand.timeError();
-
-    if (useMTDTiming_ and candidate.charge()) {
-      // Ignore HGCAL timing until it will be TOF corrected
-      time = -99.;
-      timeE = -1.;
-      // Check MTD timing availability
-      const bool assocQuality = (*trackTimeQualH)[candidate.trackRef()] > timingQualityThreshold_;
-      if (assocQuality) {
-        const auto timeHGC = time;
-        const auto timeEHGC = timeE;
-        const auto timeMTD = (*trackTimeH)[candidate.trackRef()];
-        const auto timeEMTD = (*trackTimeErrH)[candidate.trackRef()];
-
-        if (useTimingAverage_ && (timeEMTD > 0 && timeEHGC > 0)) {
-          // Compute weighted average between HGCAL and MTD timing
-          const auto invTimeESqHGC = pow(timeEHGC, -2);
-          const auto invTimeESqMTD = pow(timeEMTD, -2);
-          timeE = 1.f / (invTimeESqHGC + invTimeESqMTD);
-          time = (timeHGC * invTimeESqHGC + timeMTD * invTimeESqMTD) * timeE;
-          timeE = sqrt(timeE);
-        } else if (timeEMTD > 0) {  // Ignore HGCal timing until it will be TOF corrected
-          time = timeMTD;
-          timeE = timeEMTD;
+        if ((PFMuonAlgo::isMuon(muonref) and not (*muonH)[muId].isTrackerMuon()) or
+            (!ticl_cand.tracksters().size() and muonref.isNonnull() and muonref->isGlobalMuon())) {
+          const bool allowLoose = (part_type == reco::PFCandidate::mu);
+          // Redefine pfmuon candidate kinematics and add muonref
+          pfmu_->reconstructMuon(candidate, muonref, allowLoose);
         }
       }
     }
-    candidate.setTime(time, timeE);
+    candidate.setTime(ticl_cand.time(), ticl_cand.timeError());
   }
 
   evt.put(std::move(candidates));

--- a/RecoHGCal/TICL/plugins/PFTICLProducerV5.cc
+++ b/RecoHGCal/TICL/plugins/PFTICLProducerV5.cc
@@ -121,8 +121,8 @@ void PFTICLProducerV5::produce(edm::Event& evt, const edm::EventSetup& es) {
       const int muId = PFMuonAlgo::muAssocToTrack(trackref, muons);
       if (muId != -1) {
         const reco::MuonRef muonref = reco::MuonRef(muonH, muId);
-        if ((PFMuonAlgo::isMuon(muonref) and not (*muonH)[muId].isTrackerMuon()) or
-            (!ticl_cand.tracksters().size() and muonref.isNonnull() and muonref->isGlobalMuon())) {
+        if ((PFMuonAlgo::isMuon(muonref) and not(*muonH)[muId].isTrackerMuon()) or
+            (ticl_cand.tracksters().empty() and muonref.isNonnull() and muonref->isGlobalMuon())) {
           const bool allowLoose = (part_type == reco::PFCandidate::mu);
           // Redefine pfmuon candidate kinematics and add muonref
           pfmu_->reconstructMuon(candidate, muonref, allowLoose);

--- a/RecoHGCal/TICL/plugins/SimTrackstersProducer.cc
+++ b/RecoHGCal/TICL/plugins/SimTrackstersProducer.cc
@@ -28,6 +28,8 @@
 
 #include "SimDataFormats/CaloAnalysis/interface/CaloParticle.h"
 #include "SimDataFormats/CaloAnalysis/interface/SimCluster.h"
+#include "SimDataFormats/CaloAnalysis/interface/MtdSimTrackster.h"
+#include "SimDataFormats/CaloAnalysis/interface/MtdSimTracksterFwd.h"
 #include "RecoLocalCalo/HGCalRecAlgos/interface/RecHitTools.h"
 
 #include "SimDataFormats/Vertex/interface/SimVertex.h"
@@ -85,6 +87,7 @@ private:
 
   const edm::EDGetTokenT<std::vector<SimCluster>> simclusters_token_;
   const edm::EDGetTokenT<std::vector<CaloParticle>> caloparticles_token_;
+  const edm::EDGetTokenT<MtdSimTracksterCollection> MTDSimTrackstersToken_;
 
   const edm::EDGetTokenT<hgcal::SimToRecoCollectionWithSimClusters> associatorMapSimClusterToReco_token_;
   const edm::EDGetTokenT<hgcal::SimToRecoCollection> associatorMapCaloParticleToReco_token_;
@@ -114,6 +117,7 @@ SimTrackstersProducer::SimTrackstersProducer(const edm::ParameterSet& ps)
       filtered_layerclusters_mask_token_(consumes(ps.getParameter<edm::InputTag>("filtered_mask"))),
       simclusters_token_(consumes(ps.getParameter<edm::InputTag>("simclusters"))),
       caloparticles_token_(consumes(ps.getParameter<edm::InputTag>("caloparticles"))),
+      MTDSimTrackstersToken_(consumes<MtdSimTracksterCollection>(ps.getParameter<edm::InputTag>("MtdSimTracksters"))),
       associatorMapSimClusterToReco_token_(
           consumes(ps.getParameter<edm::InputTag>("layerClusterSimClusterAssociator"))),
       associatorMapCaloParticleToReco_token_(
@@ -146,6 +150,7 @@ void SimTrackstersProducer::fillDescriptions(edm::ConfigurationDescriptions& des
   desc.add<edm::InputTag>("filtered_mask", edm::InputTag("filteredLayerClustersSimTracksters", "ticlSimTracksters"));
   desc.add<edm::InputTag>("simclusters", edm::InputTag("mix", "MergedCaloTruth"));
   desc.add<edm::InputTag>("caloparticles", edm::InputTag("mix", "MergedCaloTruth"));
+  desc.add<edm::InputTag>("MtdSimTracksters", edm::InputTag("mix", "MergedMtdTruthST"));
   desc.add<edm::InputTag>("layerClusterSimClusterAssociator",
                           edm::InputTag("layerClusterSimClusterAssociationProducer"));
   desc.add<edm::InputTag>("layerClusterCaloParticleAssociator",
@@ -248,6 +253,9 @@ void SimTrackstersProducer::produce(edm::Event& evt, const edm::EventSetup& es) 
   edm::Handle<std::vector<CaloParticle>> caloParticles_h;
   evt.getByToken(caloparticles_token_, caloParticles_h);
   const auto& caloparticles = *caloParticles_h;
+
+  edm::Handle<MtdSimTracksterCollection> MTDSimTracksters_h;
+  evt.getByToken(MTDSimTrackstersToken_, MTDSimTracksters_h);
 
   const auto& simClustersToRecoColl = evt.get(associatorMapSimClusterToReco_token_);
   const auto& caloParticlesToRecoColl = evt.get(associatorMapCaloParticleToReco_token_);
@@ -422,6 +430,13 @@ void SimTrackstersProducer::produce(edm::Event& evt, const edm::EventSetup& es) 
 
   edm::OrphanHandle<std::vector<Trackster>> simTracksters_h = evt.put(std::move(result));
 
+  // map between simTrack and Mtd SimTracksters to loop on them only one
+  std::unordered_map<unsigned int, const MtdSimTrackster*> SimTrackToMtdST;
+  for (unsigned int i = 0; i < MTDSimTracksters_h->size(); ++i){
+    const auto& simTrack = (*MTDSimTracksters_h)[i].g4Tracks()[0];
+    SimTrackToMtdST[simTrack.trackId()] = &((*MTDSimTracksters_h)[i]);
+  }
+
   result_ticlCandidates->resize(result_fromCP->size());
   std::vector<int> toKeep;
   for (size_t i = 0; i < simTracksters_h->size(); ++i) {
@@ -457,8 +472,15 @@ void SimTrackstersProducer::produce(edm::Event& evt, const edm::EventSetup& es) 
     float rawEnergy = 0.f;
     float regressedEnergy = 0.f;
 
-    cand.setTime(simVertices[cp.g4Tracks()[0].vertIndex()].position().t() * pow(10, 9));
-    cand.setTimeError(0);
+    const auto& simTrack = cp.g4Tracks()[0];
+    auto pos = SimTrackToMtdST.find(simTrack.trackId());
+    if (pos != SimTrackToMtdST.end()) { 
+      auto MTDst = pos->second;
+      // TODO: once the associators have been implemented check if the MTDst is associated with a reco before adding the MTD time
+      cand.setMTDTime(MTDst->time(), 0);
+    }
+
+    cand.setTime(simVertices[cp.g4Tracks()[0].vertIndex()].position().t() * pow(10, 9), 0);
 
     for (const auto& trackster : cand.tracksters()) {
       rawEnergy += trackster->raw_energy();

--- a/RecoHGCal/TICL/plugins/SimTrackstersProducer.cc
+++ b/RecoHGCal/TICL/plugins/SimTrackstersProducer.cc
@@ -432,7 +432,7 @@ void SimTrackstersProducer::produce(edm::Event& evt, const edm::EventSetup& es) 
 
   // map between simTrack and Mtd SimTracksters to loop on them only one
   std::unordered_map<unsigned int, const MtdSimTrackster*> SimTrackToMtdST;
-  for (unsigned int i = 0; i < MTDSimTracksters_h->size(); ++i){
+  for (unsigned int i = 0; i < MTDSimTracksters_h->size(); ++i) {
     const auto& simTrack = (*MTDSimTracksters_h)[i].g4Tracks()[0];
     SimTrackToMtdST[simTrack.trackId()] = &((*MTDSimTracksters_h)[i]);
   }
@@ -474,7 +474,7 @@ void SimTrackstersProducer::produce(edm::Event& evt, const edm::EventSetup& es) 
 
     const auto& simTrack = cp.g4Tracks()[0];
     auto pos = SimTrackToMtdST.find(simTrack.trackId());
-    if (pos != SimTrackToMtdST.end()) { 
+    if (pos != SimTrackToMtdST.end()) {
       auto MTDst = pos->second;
       // TODO: once the associators have been implemented check if the MTDst is associated with a reco before adding the MTD time
       cand.setMTDTime(MTDst->time(), 0);

--- a/RecoHGCal/TICL/plugins/TICLCandidateProducer.cc
+++ b/RecoHGCal/TICL/plugins/TICLCandidateProducer.cc
@@ -197,10 +197,10 @@ TICLCandidateProducer::TICLCandidateProducer(const edm::ParameterSet &ps)
     original_masks_tokens_.emplace_back(consumes<std::vector<float>>(tag));
   }
 
+  std::string detectorName_ = (detector_ == "HFNose") ? "HGCalHFNoseSensitive" : "HGCalEESensitive";
+  hdc_token_ =
+      esConsumes<HGCalDDDConstants, IdealGeometryRecord, edm::Transition::BeginRun>(edm::ESInputTag("", detectorName_));
   if (useMTDTiming_) {
-    std::string detectorName_ = (detector_ == "HFNose") ? "HGCalHFNoseSensitive" : "HGCalEESensitive";
-    hdc_token_ = esConsumes<HGCalDDDConstants, IdealGeometryRecord, edm::Transition::BeginRun>(
-        edm::ESInputTag("", detectorName_));
     inputTimingToken_ = consumes<MtdHostCollection>(ps.getParameter<edm::InputTag>("timingSoA"));
   }
 

--- a/RecoHGCal/TICL/plugins/TICLCandidateProducer.cc
+++ b/RecoHGCal/TICL/plugins/TICLCandidateProducer.cc
@@ -626,8 +626,7 @@ if( inputTimingView.timeErr()[trackIndex] > 0) {
       time = time / invTimeErr;
       // FIXME_ set a liminf of 0.02 ns on the ts error (based on residuals)
       timeErr = sqrt(1.f / invTimeErr) > 0.02 ? sqrt(1.f / invTimeErr) : 0.02;
-      cand.setTime(time);
-      cand.setTimeError(timeErr);
+      cand.setTime(time, timeErr);
     }
 
     if (useMTDTiming_ and cand.charge()) {
@@ -653,8 +652,8 @@ if( inputTimingView.timeErr()[trackIndex] > 0) {
           timeErr = timeEMTD;
         }
       }
-      cand.setTime(time);
-      cand.setTimeError(timeErr);
+      cand.setTime(time, timeErr);
+      cand.setMTDTime(inputTimingView.time()[trackIndex], inputTimingView.timeErr()[trackIndex]);
     }
   }
 }

--- a/RecoHGCal/TICL/plugins/TICLCandidateProducer.cc
+++ b/RecoHGCal/TICL/plugins/TICLCandidateProducer.cc
@@ -245,7 +245,7 @@ void filterTracks(edm::Handle<std::vector<reco::Track>> tkH,
     int muId = PFMuonAlgo::muAssocToTrack(trackref, *muons_h);
     const reco::MuonRef muonref = reco::MuonRef(muons_h, muId);
 
-    if (!cutTk_((tk)) or (muId != -1 and PFMuonAlgo::isMuon(muonref) and not (*muons_h)[muId].isTrackerMuon())) {
+    if (!cutTk_((tk)) or (muId != -1 and PFMuonAlgo::isMuon(muonref) and not(*muons_h)[muId].isTrackerMuon())) {
       maskTracks[i] = false;
       continue;
     }
@@ -438,8 +438,7 @@ void TICLCandidateProducer::produce(edm::Event &evt, const edm::EventSetup &es) 
         return 0.f;
       };
 
-  assignTimeToCandidates(
-      *resultCandidates, tracks_h, inputTiming_h, trjtrks, getPathLength);
+  assignTimeToCandidates(*resultCandidates, tracks_h, inputTiming_h, trjtrks, getPathLength);
 
   evt.put(std::move(resultCandidates));
 }
@@ -571,12 +570,11 @@ void TICLCandidateProducer::energyRegressionAndID(const std::vector<reco::CaloCl
 }
 
 template <typename F>
-void TICLCandidateProducer::assignTimeToCandidates(
-    std::vector<TICLCandidate> &resultCandidates,
-    edm::Handle<std::vector<reco::Track>> track_h,
-    edm::Handle<MtdHostCollection> inputTiming_h,
-    TrajTrackAssociationCollection trjtrks,
-    F func) const {
+void TICLCandidateProducer::assignTimeToCandidates(std::vector<TICLCandidate> &resultCandidates,
+                                                   edm::Handle<std::vector<reco::Track>> track_h,
+                                                   edm::Handle<MtdHostCollection> inputTiming_h,
+                                                   TrajTrackAssociationCollection trjtrks,
+                                                   F func) const {
   for (auto &cand : resultCandidates) {
     float beta = 1;
     float time = 0.f;
@@ -593,16 +591,17 @@ void TICLCandidateProducer::assignTimeToCandidates(
         if (cand.trackPtr().get() != nullptr) {
           const auto &trackIndex = cand.trackPtr().get() - (edm::Ptr<reco::Track>(track_h, 0)).get();
           if (useMTDTiming_) {
- auto const& inputTimingView = (*inputTiming_h).const_view();
-if( inputTimingView.timeErr()[trackIndex] > 0) {
-            const auto xMtd = inputTimingView.posInMTD_x()[trackIndex]; 
-            const auto yMtd = inputTimingView.posInMTD_y()[trackIndex]; 
-            const auto zMtd = inputTimingView.posInMTD_z()[trackIndex]; 
+            auto const &inputTimingView = (*inputTiming_h).const_view();
+            if (inputTimingView.timeErr()[trackIndex] > 0) {
+              const auto xMtd = inputTimingView.posInMTD_x()[trackIndex];
+              const auto yMtd = inputTimingView.posInMTD_y()[trackIndex];
+              const auto zMtd = inputTimingView.posInMTD_z()[trackIndex];
 
-            beta = inputTimingView.beta()[trackIndex];
-            path = std::sqrt((x - xMtd) * (x - xMtd) + (y - yMtd) * (y - yMtd) + (z - zMtd) * (z - zMtd)) +
-                   inputTimingView.pathLength()[trackIndex];
-}          } else {
+              beta = inputTimingView.beta()[trackIndex];
+              path = std::sqrt((x - xMtd) * (x - xMtd) + (y - yMtd) * (y - yMtd) + (z - zMtd) * (z - zMtd)) +
+                     inputTimingView.pathLength()[trackIndex];
+            }
+          } else {
             const auto &trackIndex = cand.trackPtr().get() - (edm::Ptr<reco::Track>(track_h, 0)).get();
             for (const auto &trj : trjtrks) {
               if (trj.val != edm::Ref<std::vector<reco::Track>>(track_h, trackIndex))
@@ -631,7 +630,7 @@ if( inputTimingView.timeErr()[trackIndex] > 0) {
 
     if (useMTDTiming_ and cand.charge()) {
       // Check MTD timing availability
- auto const& inputTimingView = (*inputTiming_h).const_view();
+      auto const &inputTimingView = (*inputTiming_h).const_view();
       const auto &trackIndex = cand.trackPtr().get() - (edm::Ptr<reco::Track>(track_h, 0)).get();
       const bool assocQuality = inputTimingView.MVAquality()[trackIndex] > timingQualityThreshold_;
       if (assocQuality) {

--- a/RecoHGCal/TICL/plugins/TICLDumper.cc
+++ b/RecoHGCal/TICL/plugins/TICLDumper.cc
@@ -745,7 +745,8 @@ void TICLDumper::clearVariables() {
 
 TICLDumper::TICLDumper(const edm::ParameterSet& ps)
     : tracksters_token_(consumes<std::vector<ticl::Trackster>>(ps.getParameter<edm::InputTag>("trackstersclue3d"))),
-      tracksters_in_candidate_token_(consumes<std::vector<ticl::Trackster>>(ps.getParameter<edm::InputTag>("trackstersInCand"))),
+      tracksters_in_candidate_token_(
+          consumes<std::vector<ticl::Trackster>>(ps.getParameter<edm::InputTag>("trackstersInCand"))),
       layer_clusters_token_(consumes<std::vector<reco::CaloCluster>>(ps.getParameter<edm::InputTag>("layerClusters"))),
       ticl_candidates_token_(consumes<std::vector<TICLCandidate>>(ps.getParameter<edm::InputTag>("ticlcandidates"))),
       tracks_token_(consumes<std::vector<reco::Track>>(ps.getParameter<edm::InputTag>("tracks"))),
@@ -2096,13 +2097,13 @@ void TICLDumper::analyze(const edm::Event& event, const edm::EventSetup& setup) 
       track_pos_mtd.push_back(trackPosMtd[trackref]);
       track_nhits.push_back(tracks[i].recHitsSize());
       int muId = PFMuonAlgo::muAssocToTrack(trackref, *muons_h);
-      if (muId != -1 ) {
-      const reco::MuonRef muonref = reco::MuonRef(muons_h, muId);
-      track_isMuon.push_back(PFMuonAlgo::isMuon(muonref));
-      track_isTrackerMuon.push_back(muons[muId].isTrackerMuon());
+      if (muId != -1) {
+        const reco::MuonRef muonref = reco::MuonRef(muons_h, muId);
+        track_isMuon.push_back(PFMuonAlgo::isMuon(muonref));
+        track_isTrackerMuon.push_back(muons[muId].isTrackerMuon());
       } else {
-      track_isMuon.push_back(-1);
-      track_isTrackerMuon.push_back(-1);
+        track_isMuon.push_back(-1);
+        track_isTrackerMuon.push_back(-1);
       }
     }
   }

--- a/RecoHGCal/TICL/plugins/TICLDumper.cc
+++ b/RecoHGCal/TICL/plugins/TICLDumper.cc
@@ -316,6 +316,7 @@ private:
   std::vector<int> candidate_charge;
   std::vector<int> candidate_pdgId;
   std::vector<float> candidate_energy;
+  std::vector<float> candidate_raw_energy;
   std::vector<double> candidate_px;
   std::vector<double> candidate_py;
   std::vector<double> candidate_pz;
@@ -424,6 +425,7 @@ private:
   std::vector<float> track_pt;
   std::vector<int> track_quality;
   std::vector<int> track_missing_outer_hits;
+  std::vector<int> track_missing_inner_hits;
   std::vector<int> track_charge;
   std::vector<double> track_time;
   std::vector<float> track_time_quality;
@@ -604,6 +606,7 @@ void TICLDumper::clearVariables() {
   candidate_charge.clear();
   candidate_pdgId.clear();
   candidate_energy.clear();
+  candidate_raw_energy.clear();
   candidate_px.clear();
   candidate_py.clear();
   candidate_pz.clear();
@@ -720,6 +723,7 @@ void TICLDumper::clearVariables() {
   track_quality.clear();
   track_pt.clear();
   track_missing_outer_hits.clear();
+  track_missing_inner_hits.clear();
   track_charge.clear();
   track_time.clear();
   track_time_quality.clear();
@@ -878,6 +882,7 @@ void TICLDumper::beginJob() {
     candidate_tree_->Branch("candidate_time", &candidate_time);
     candidate_tree_->Branch("candidate_timeErr", &candidate_time_err);
     candidate_tree_->Branch("candidate_energy", &candidate_energy);
+    candidate_tree_->Branch("candidate_raw_energy", &candidate_raw_energy);
     candidate_tree_->Branch("candidate_px", &candidate_px);
     candidate_tree_->Branch("candidate_py", &candidate_py);
     candidate_tree_->Branch("candidate_pz", &candidate_pz);
@@ -1092,6 +1097,7 @@ void TICLDumper::beginJob() {
     tracks_tree_->Branch("track_hgcal_pt", &track_hgcal_pt);
     tracks_tree_->Branch("track_pt", &track_pt);
     tracks_tree_->Branch("track_missing_outer_hits", &track_missing_outer_hits);
+    tracks_tree_->Branch("track_missing_inner_hits", &track_missing_inner_hits);
     tracks_tree_->Branch("track_quality", &track_quality);
     tracks_tree_->Branch("track_charge", &track_charge);
     tracks_tree_->Branch("track_time", &track_time);
@@ -1743,6 +1749,7 @@ void TICLDumper::analyze(const edm::Event& event, const edm::EventSetup& setup) 
     candidate_charge.push_back(candidate.charge());
     candidate_pdgId.push_back(candidate.pdgId());
     candidate_energy.push_back(candidate.energy());
+    candidate_raw_energy.push_back(candidate.rawEnergy());
     candidate_px.push_back(candidate.px());
     candidate_py.push_back(candidate.py());
     candidate_pz.push_back(candidate.pz());
@@ -2058,6 +2065,7 @@ void TICLDumper::analyze(const edm::Event& event, const edm::EventSetup& setup) 
       track_pt.push_back(track.pt());
       track_quality.push_back(track.quality(reco::TrackBase::highPurity));
       track_missing_outer_hits.push_back(track.missingOuterHits());
+      track_missing_inner_hits.push_back(track.missingInnerHits());
       track_charge.push_back(track.charge());
       track_time.push_back(trackTime[trackref]);
       track_time_quality.push_back(trackTimeQual[trackref]);

--- a/RecoHGCal/TICL/plugins/TICLDumper.cc
+++ b/RecoHGCal/TICL/plugins/TICLDumper.cc
@@ -24,6 +24,7 @@
 #include "DataFormats/CaloRecHit/interface/CaloCluster.h"
 #include "DataFormats/HGCalReco/interface/Trackster.h"
 #include "DataFormats/HGCalReco/interface/TICLCandidate.h"
+#include "DataFormats/MuonReco/interface/Muon.h"
 #include "DataFormats/TrackReco/interface/Track.h"
 #include "DataFormats/TrackReco/interface/TrackFwd.h"
 #include "DataFormats/DetId/interface/DetId.h"
@@ -34,6 +35,7 @@
 #include "SimDataFormats/CaloAnalysis/interface/SimCluster.h"
 
 #include "RecoLocalCalo/HGCalRecAlgos/interface/RecHitTools.h"
+#include "RecoParticleFlow/PFProducer/interface/PFMuonAlgo.h"
 #include "TrackingTools/TrajectoryState/interface/TrajectoryStateTransform.h"
 #include "TrackingTools/GeomPropagators/interface/Propagator.h"
 #include "TrackingTools/Records/interface/TrackingComponentsRecord.h"
@@ -80,6 +82,7 @@ private:
 
   // Define Tokens
   const edm::EDGetTokenT<std::vector<ticl::Trackster>> tracksters_token_;
+  const edm::EDGetTokenT<std::vector<ticl::Trackster>> tracksters_in_candidate_token_;
   const edm::EDGetTokenT<std::vector<reco::CaloCluster>> layer_clusters_token_;
   const edm::EDGetTokenT<std::vector<TICLCandidate>> ticl_candidates_token_;
   const edm::EDGetTokenT<std::vector<reco::Track>> tracks_token_;
@@ -100,6 +103,7 @@ private:
   const edm::EDGetTokenT<std::vector<double>> hgcaltracks_py_token_;
   const edm::EDGetTokenT<std::vector<double>> hgcaltracks_pz_token_;
   const edm::EDGetTokenT<std::vector<ticl::Trackster>> tracksters_merged_token_;
+  const edm::EDGetTokenT<std::vector<reco::Muon>> muons_token_;
   const edm::EDGetTokenT<edm::ValueMap<std::pair<float, float>>> clustersTime_token_;
   const edm::EDGetTokenT<std::vector<int>> tracksterSeeds_token_;
   edm::ESGetToken<CaloGeometry, CaloGeometryRecord> caloGeometry_token_;
@@ -435,6 +439,8 @@ private:
   std::vector<float> track_time_mtd_err;
   std::vector<GlobalPoint> track_pos_mtd;
   std::vector<int> track_nhits;
+  std::vector<int> track_isMuon;
+  std::vector<int> track_isTrackerMuon;
 
   TTree* trackster_tree_;
   TTree* cluster_tree_;
@@ -733,10 +739,13 @@ void TICLDumper::clearVariables() {
   track_time_mtd_err.clear();
   track_pos_mtd.clear();
   track_nhits.clear();
+  track_isMuon.clear();
+  track_isTrackerMuon.clear();
 };
 
 TICLDumper::TICLDumper(const edm::ParameterSet& ps)
     : tracksters_token_(consumes<std::vector<ticl::Trackster>>(ps.getParameter<edm::InputTag>("trackstersclue3d"))),
+      tracksters_in_candidate_token_(consumes<std::vector<ticl::Trackster>>(ps.getParameter<edm::InputTag>("trackstersInCand"))),
       layer_clusters_token_(consumes<std::vector<reco::CaloCluster>>(ps.getParameter<edm::InputTag>("layerClusters"))),
       ticl_candidates_token_(consumes<std::vector<TICLCandidate>>(ps.getParameter<edm::InputTag>("ticlcandidates"))),
       tracks_token_(consumes<std::vector<reco::Track>>(ps.getParameter<edm::InputTag>("tracks"))),
@@ -749,6 +758,7 @@ TICLDumper::TICLDumper(const edm::ParameterSet& ps)
       tracks_pos_mtd_token_(consumes<edm::ValueMap<GlobalPoint>>(ps.getParameter<edm::InputTag>("tracksPosMtd"))),
       tracksters_merged_token_(
           consumes<std::vector<ticl::Trackster>>(ps.getParameter<edm::InputTag>("trackstersmerged"))),
+      muons_token_(consumes<std::vector<reco::Muon>>(ps.getParameter<edm::InputTag>("muons"))),
       clustersTime_token_(
           consumes<edm::ValueMap<std::pair<float, float>>>(ps.getParameter<edm::InputTag>("layer_clustersTime"))),
       caloGeometry_token_(esConsumes<CaloGeometry, CaloGeometryRecord, edm::Transition::BeginRun>()),
@@ -1108,6 +1118,8 @@ void TICLDumper::beginJob() {
     tracks_tree_->Branch("track_time_mtd_err", &track_time_mtd_err);
     tracks_tree_->Branch("track_pos_mtd", &track_pos_mtd);
     tracks_tree_->Branch("track_nhits", &track_nhits);
+    tracks_tree_->Branch("track_isMuon", &track_isMuon);
+    tracks_tree_->Branch("track_isTrackerMuon", &track_isTrackerMuon);
   }
 
   if (saveSimTICLCandidate_) {
@@ -1176,6 +1188,9 @@ void TICLDumper::analyze(const edm::Event& event, const edm::EventSetup& setup) 
   event.getByToken(tracksters_token_, tracksters_handle);
   const auto& tracksters = *tracksters_handle;
 
+  edm::Handle<std::vector<ticl::Trackster>> tracksters_in_candidate_handle;
+  event.getByToken(tracksters_in_candidate_token_, tracksters_in_candidate_handle);
+
   //get all the layer clusters
   edm::Handle<std::vector<reco::CaloCluster>> layer_clusters_h;
   event.getByToken(layer_clusters_token_, layer_clusters_h);
@@ -1227,6 +1242,11 @@ void TICLDumper::analyze(const edm::Event& event, const edm::EventSetup& setup) 
   edm::Handle<std::vector<ticl::Trackster>> tracksters_merged_h;
   event.getByToken(tracksters_merged_token_, tracksters_merged_h);
   const auto& trackstersmerged = *tracksters_merged_h;
+
+  // muons
+  edm::Handle<std::vector<reco::Muon>> muons_h;
+  event.getByToken(muons_token_, muons_h);
+  auto& muons = *muons_h;
 
   // simTracksters from SC
   edm::Handle<std::vector<ticl::Trackster>> simTrackstersSC_h;
@@ -1765,7 +1785,7 @@ void TICLDumper::analyze(const edm::Event& event, const edm::EventSetup& setup) 
     auto trackster_ptrs = candidate.tracksters();
     auto track_ptr = candidate.trackPtr();
     for (const auto& ts_ptr : trackster_ptrs) {
-      auto ts_idx = ts_ptr.get() - (edm::Ptr<ticl::Trackster>(tracksters_merged_h, 0)).get();
+      auto ts_idx = ts_ptr.get() - (edm::Ptr<ticl::Trackster>(tracksters_in_candidate_handle, 0)).get();
       tracksters_in_candidate[i].push_back(ts_idx);
     }
     if (track_ptr.isNull())
@@ -2075,6 +2095,15 @@ void TICLDumper::analyze(const edm::Event& event, const edm::EventSetup& setup) 
       track_time_mtd_err.push_back(trackTimeMtdErr[trackref]);
       track_pos_mtd.push_back(trackPosMtd[trackref]);
       track_nhits.push_back(tracks[i].recHitsSize());
+      int muId = PFMuonAlgo::muAssocToTrack(trackref, *muons_h);
+      if (muId != -1 ) {
+      const reco::MuonRef muonref = reco::MuonRef(muons_h, muId);
+      track_isMuon.push_back(PFMuonAlgo::isMuon(muonref));
+      track_isTrackerMuon.push_back(muons[muId].isTrackerMuon());
+      } else {
+      track_isMuon.push_back(-1);
+      track_isTrackerMuon.push_back(-1);
+      }
     }
   }
 
@@ -2103,6 +2132,7 @@ void TICLDumper::endJob() {}
 void TICLDumper::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   edm::ParameterSetDescription desc;
   desc.add<edm::InputTag>("trackstersclue3d", edm::InputTag("ticlTrackstersCLUE3DHigh"));
+  desc.add<edm::InputTag>("trackstersInCand", edm::InputTag("ticlTrackstersCLUE3DHigh"));
   desc.add<edm::InputTag>("layerClusters", edm::InputTag("hgcalMergeLayerClusters"));
   desc.add<edm::InputTag>("layer_clustersTime", edm::InputTag("hgcalMergeLayerClusters", "timeLayerCluster"));
   desc.add<edm::InputTag>("ticlcandidates", edm::InputTag("ticlTrackstersMerge"));
@@ -2115,6 +2145,7 @@ void TICLDumper::fillDescriptions(edm::ConfigurationDescriptions& descriptions) 
   desc.add<edm::InputTag>("tracksTimeMtdErr", edm::InputTag("trackExtenderWithMTD:generalTracksigmatmtd"));
   desc.add<edm::InputTag>("tracksPosMtd", edm::InputTag("trackExtenderWithMTD:generalTrackmtdpos"));
   desc.add<edm::InputTag>("trackstersmerged", edm::InputTag("ticlTrackstersMerge"));
+  desc.add<edm::InputTag>("muons", edm::InputTag("muons1stStep"));
   desc.add<edm::InputTag>("simtrackstersSC", edm::InputTag("ticlSimTracksters"));
   desc.add<edm::InputTag>("simtrackstersCP", edm::InputTag("ticlSimTracksters", "fromCPs"));
   desc.add<edm::InputTag>("simtrackstersPU", edm::InputTag("ticlSimTracksters", "PU"));

--- a/RecoHGCal/TICL/plugins/TrackstersMergeProducer.cc
+++ b/RecoHGCal/TICL/plugins/TrackstersMergeProducer.cc
@@ -559,8 +559,7 @@ void TrackstersMergeProducer::assignTimeToCandidates(std::vector<TICLCandidate> 
         }
       }
       if (invTimeErr > 0) {
-        cand.setTime(time / invTimeErr);
-        cand.setTimeError(sqrt(1.f / invTimeErr));
+        cand.setTime(time / invTimeErr, sqrt(1.f / invTimeErr));
       }
     }
   }

--- a/RecoHGCal/TICL/plugins/TrackstersMergeProducerV3.cc
+++ b/RecoHGCal/TICL/plugins/TrackstersMergeProducerV3.cc
@@ -677,8 +677,7 @@ void TrackstersMergeProducerV3::assignTimeToCandidates(std::vector<TICLCandidate
       if (timeErr > 0) {
         timeErr = 1. / timeErr;
 
-        cand.setTime(time * timeErr);
-        cand.setTimeError(sqrt(timeErr));
+        cand.setTime(time * timeErr, sqrt(timeErr));
       }
     }
   }

--- a/RecoHGCal/TICL/python/customiseForTICLv5_cff.py
+++ b/RecoHGCal/TICL/python/customiseForTICLv5_cff.py
@@ -31,6 +31,7 @@ from RecoHGCal.TICL.CLUE3DHAD_cff import ticlTrackstersCLUE3DHAD
 from RecoHGCal.TICL.CLUE3DHighStep_cff import ticlTrackstersCLUE3DHigh
 from RecoHGCal.TICL.TrkEMStep_cff import ticlTrackstersTrkEM, filteredLayerClustersHFNoseTrkEM
 
+from RecoHGCal.TICL.mtdSoAProducer_cfi import mtdSoAProducer as _mtdSoAProducer
 
 def customiseForTICLv5(process, enableDumper = False):
 
@@ -65,6 +66,9 @@ def customiseForTICLv5(process, enableDumper = False):
         ticlCLUE3DHADStepTask,
     )
 
+    process.mtdSoA = _mtdSoAProducer.clone()
+    process.mtdSoATask = cms.Task(process.mtdSoA)
+
     process.ticlTracksterLinks = _tracksterLinksProducer.clone()
     process.ticlTracksterLinksTask = cms.Task(process.ticlTracksterLinks)
 
@@ -93,6 +97,7 @@ def customiseForTICLv5(process, enableDumper = False):
         label_tst = cms.InputTag("mergedTrackstersProducer")
         )
     process.iterTICLTask = cms.Task(process.ticlLayerTileTask,
+                                     process.mtdSoATask,
                                      process.ticlIterationsTask,
                                      process.ticlTracksterLinksTask,
                                      process.ticlCandidateTask)

--- a/RecoHGCal/TICL/python/customiseForTICLv5_cff.py
+++ b/RecoHGCal/TICL/python/customiseForTICLv5_cff.py
@@ -4,10 +4,9 @@ from RecoHGCal.TICL.ticlLayerTileProducer_cfi import ticlLayerTileProducer
 
 from RecoHGCal.TICL.CLUE3DEM_cff import *
 from RecoHGCal.TICL.CLUE3DHAD_cff import *
-from RecoHGCal.TICL.pfTICLProducer_cfi import pfTICLProducer as _pfTICLProducer
+from RecoHGCal.TICL.pfTICLProducerV5_cfi import pfTICLProducerV5 as _pfTICLProducerV5
 
 from RecoHGCal.TICL.ticlLayerTileProducer_cfi import ticlLayerTileProducer
-from RecoHGCal.TICL.pfTICLProducer_cfi import pfTICLProducer as _pfTICLProducer
 from RecoHGCal.TICL.tracksterSelectionTf_cfi import *
 
 from RecoHGCal.TICL.tracksterLinksProducer_cfi import tracksterLinksProducer as _tracksterLinksProducer
@@ -106,7 +105,7 @@ def customiseForTICLv5(process, enableDumper = False):
     process.tracksterSimTracksterAssociationLinkingPU.label_tst = cms.InputTag("ticlTracksterLinks")
     process.tracksterSimTracksterAssociationPRPU.label_tst = cms.InputTag("ticlTracksterLinks")
     process.mergeTICLTask = cms.Task()
-    process.pfTICL.ticlCandidateSrc = cms.InputTag("ticlCandidate") 
+    process.pfTICL = _pfTICLProducerV5.clone()
     process.hgcalAssociators = cms.Task(process.mergedTrackstersProducer, process.lcAssocByEnergyScoreProducer, process.layerClusterCaloParticleAssociationProducer,
                             process.scAssocByEnergyScoreProducer, process.layerClusterSimClusterAssociationProducer,
                             process.lcSimTSAssocByEnergyScoreProducer, process.layerClusterSimTracksterAssociationProducer,
@@ -139,7 +138,8 @@ def customiseForTICLv5(process, enableDumper = False):
             saveAssociations=True,
             trackstersclue3d = cms.InputTag('mergedTrackstersProducer'),
             ticlcandidates = cms.InputTag("ticlCandidate"),
-            trackstersmerged = cms.InputTag("ticlCandidate")
+            trackstersmerged = cms.InputTag("ticlCandidate"),
+            trackstersInCand = cms.InputTag("ticlCandidate")
         )
         process.TFileService = cms.Service("TFileService",
                                            fileName=cms.string("histo.root")

--- a/RecoHGCal/TICL/python/iterativeTICL_cff.py
+++ b/RecoHGCal/TICL/python/iterativeTICL_cff.py
@@ -18,12 +18,14 @@ from RecoHGCal.TICL.tracksterSelectionTf_cfi import *
 from RecoHGCal.TICL.tracksterLinksProducer_cfi import tracksterLinksProducer as _tracksterLinksProducer
 from RecoHGCal.TICL.ticlCandidateProducer_cfi import ticlCandidateProducer as _ticlCandidateProducer
 
+from RecoHGCal.TICL.mtdSoAProducer_cfi import mtdSoAProducer as _mtdSoAProducer
 
 ticlLayerTileTask = cms.Task(ticlLayerTileProducer)
 
 ticlTrackstersMerge = _trackstersMergeProducer.clone()
 ticlTracksterLinks = _tracksterLinksProducer.clone()
 ticlCandidate = _ticlCandidateProducer.clone()
+mtdSoA = _mtdSoAProducer.clone()
 
 pfTICL = _pfTICLProducer.clone()
 ticlPFTask = cms.Task(pfTICL)
@@ -34,7 +36,7 @@ ticlIterationsTask = cms.Task(
     ticlCLUE3DHighStepTask
 )
 
-ticlCandidateTask = cms.Task(ticlCandidate)
+ticlCandidateTask = cms.Task(mtdSoA, ticlCandidate)
 
 
 from Configuration.ProcessModifiers.fastJetTICL_cff import fastJetTICL

--- a/Validation/HGCalValidation/python/PostProcessorHGCAL_cfi.py
+++ b/Validation/HGCalValidation/python/PostProcessorHGCAL_cfi.py
@@ -85,27 +85,26 @@ postProcessorHGCALTracksters = DQMEDHarvester('DQMGenericClient',
 
 neutrals = ["photons", "neutral_pions", "neutral_hadrons"]
 charged = ["electrons", "muons", "charged_hadrons"]
-variables = ["energy", "pt", "eta", "phi"]
 subDirsCandidates = [prefix + hgcalValidator.ticlCandidates.value() + "/" + c for cands in (neutrals, charged) for c in cands]
 eff_candidates = []
 
 for c in charged:
-    for var in variables:
+    for var in variables.keys():
         eff_candidates.append("eff_"+c+"_track_"+var+" '"+c.replace("_", " ")+" candidates track efficiency vs "+var+"' num_track_cand_vs_"+var+"_"+c+" den_cand_vs_"+var+"_"+c)
         eff_candidates.append("eff_"+c+"_pid_"+var+" '"+c.replace("_", " ")+" candidates track + pid efficiency vs "+var+"' num_pid_cand_vs_"+var+"_"+c+" den_cand_vs_"+var+"_"+c)
         eff_candidates.append("eff_"+c+"_energy_"+var+" '"+c.replace("_", " ")+" candidates track + pid + energy efficiency vs "+var+"' num_energy_cand_vs_"+var+"_"+c+" den_cand_vs_"+var+"_"+c)
 for n in neutrals:
-    for var in variables:
+    for var in variables.keys():
         eff_candidates.append("eff_"+n+"_pid_"+var+" '"+n.replace("_", " ")+" candidates pid efficiency vs "+var+"' num_pid_cand_vs_"+var+"_"+n+" den_cand_vs_"+var+"_"+n)
         eff_candidates.append("eff_"+n+"_energy_"+var+" '"+n.replace("_", " ")+" candidates pid + energy efficiency vs "+var+"' num_energy_cand_vs_"+var+"_"+n+" den_cand_vs_"+var+"_"+n)
 
 for c in charged:
-    for var in variables:
+    for var in variables.keys():
         eff_candidates.append("fake_"+c+"_track_"+var+" '"+c.replace("_", " ")+" candidates track fake vs "+var+"' num_fake_track_cand_vs_"+var+"_"+c+" den_fake_cand_vs_"+var+"_"+c)
         eff_candidates.append("fake_"+c+"_pid_"+var+" '"+c.replace("_", " ")+" candidates track + pid fake vs "+var+"' num_fake_pid_cand_vs_"+var+"_"+c+" den_fake_cand_vs_"+var+"_"+c)
         eff_candidates.append("fake_"+c+"_energy_"+var+" '"+c.replace("_", " ")+" candidates track + pid + energy fake vs "+var+"' num_fake_energy_cand_vs_"+var+"_"+c+" den_fake_cand_vs_"+var+"_"+c)
 for n in neutrals:
-    for var in variables:
+    for var in variables.keys():
         eff_candidates.append("fake_"+n+"_pid_"+var+" '"+n.replace("_", " ")+" candidates pid fake vs "+var+"' num_fake_pid_cand_vs_"+var+"_"+n+" den_fake_cand_vs_"+var+"_"+n)
         eff_candidates.append("fake_"+n+"_energy_"+var+" '"+n.replace("_", " ")+" candidates pid + energy fake vs "+var+"' num_fake_energy_cand_vs_"+var+"_"+n+" den_fake_cand_vs_"+var+"_"+n)
 


### PR DESCRIPTION
- the combination of HGCAL and ETL time is done in the `TICLCandidateProducer` instead of `PFTICLProducer`
- ETL time quality with MVA is used w/ a threshold of 0.5
- tracker muons (seeded from the tracker and little activity in the muon chambers) are considered for the linking and create muon candidates only if they have not been linked and are global muons
- created MTD SoA to store timing info in a single collection
- ETL time stored in  candidates

TODO:
- when MTD associators will be available, check if there is a reco cluster associated with the sim before assigning ETL true time to simTICLCandidates
- after 14_0_0_pre3 use `PortableHostCollectionReadRules` in `classes.cc` for the SoA instead of declaring the rules in the `classes_def.xml`