### PR TITLE
fox new associators in validation

### DIFF
--- a/RecoHGCal/TICL/python/customiseForTICLv5_cff.py
+++ b/RecoHGCal/TICL/python/customiseForTICLv5_cff.py
@@ -111,13 +111,14 @@ def customiseTICLv5FromReco(process, enableDumper = False):
     process.hgcalAssociators = cms.Task(process.hgcalRecHitMapProducer, process.lcAssocByEnergyScoreProducer, process.layerClusterCaloParticleAssociationProducer,
                             process.scAssocByEnergyScoreProducer, process.layerClusterSimClusterAssociationProducer,
                             # FP 07/2024 new associators:
-                            layerClusterToCLUE3DTracksterAssociation, layerClusterToTracksterMergeAssociation,
-                            layerClusterToSimTracksterAssociation,
-                            hitToTrackstersAssociationLinking, hitToTrackstersAssociationPR,
-                            hitToSimTracksterAssociation, hitToSimTracksterFromCPsAssociation,
-                            tracksterSimTracksterAssociationByHitsLinking, tracksterSimTracksterAssociationByHitsPR,
-                            tracksterSimTracksterFromCPsAssociationLinking, tracksterSimTracksterAssociationLinking, tracksterSimTracksterFromCPsAssociationPR, tracksterSimTracksterAssociationPR,
-                            hitToSimClusterCaloParticleAssociator, SimClusterToCaloParticleAssociation,
+                            process.layerClusterToCLUE3DTracksterAssociation, process.layerClusterToTracksterMergeAssociation,
+                            process.layerClusterToSimTracksterAssociation, process.layerClusterToSimTracksterFromCPsAssociation,
+                            process.hitToTrackstersAssociationLinking, process.hitToTrackstersAssociationPR,
+                            process.hitToSimTracksterAssociation, process.hitToSimTracksterFromCPsAssociation,
+                            process.tracksterSimTracksterAssociationByHitsLinking, process.tracksterSimTracksterAssociationByHitsPR,
+                            process.tracksterSimTracksterFromCPsAssociationLinking, process.tracksterSimTracksterAssociationLinking,
+                            process.tracksterSimTracksterFromCPsAssociationPR, process.tracksterSimTracksterAssociationPR,
+                            process.hitToSimClusterCaloParticleAssociator, process.SimClusterToCaloParticleAssociation,
                             )
 
     if(enableDumper):

--- a/SimCalorimetry/HGCalAssociatorProducers/plugins/SimClusterToCaloParticleAssociatorProducer.cc
+++ b/SimCalorimetry/HGCalAssociatorProducers/plugins/SimClusterToCaloParticleAssociatorProducer.cc
@@ -41,7 +41,7 @@ void SimClusterToCaloParticleAssociatorProducer::produce(edm::StreamID, edm::Eve
     }
   }
 std::cout << "I'm running" << std::endl;
-  iEvent.put(std::move(simClusterToCaloParticleMap));
+  iEvent.put(std::move(simClusterToCaloParticleMap), "simClusterToCaloParticleMap");
 }
 
 void SimClusterToCaloParticleAssociatorProducer::fillDescriptions(edm::ConfigurationDescriptions &descriptions) {

--- a/SimCalorimetry/HGCalAssociatorProducers/python/LCToTSAssociator_cfi.py
+++ b/SimCalorimetry/HGCalAssociatorProducers/python/LCToTSAssociator_cfi.py
@@ -19,5 +19,9 @@ layerClusterToSimTracksterAssociation = LCToTSAssociatorProducer.clone(
     tracksters = cms.InputTag("ticlSimTracksters")
 )
 
+layerClusterToSimTracksterFromCPsAssociation = LCToTSAssociatorProducer.clone(
+    tracksters = cms.InputTag("ticlSimTracksters", "fromCPs")
+)
+
 from Configuration.ProcessModifiers.ticl_v5_cff import ticl_v5
 ticl_v5.toModify(layerClusterToTracksterMergeAssociation, tracksters = cms.InputTag("ticlCandidate"))

--- a/SimCalorimetry/HGCalAssociatorProducers/python/SimClusterToCaloParticleAssociation_cfi.py
+++ b/SimCalorimetry/HGCalAssociatorProducers/python/SimClusterToCaloParticleAssociation_cfi.py
@@ -1,7 +1,7 @@
 import FWCore.ParameterSet.Config as cms
-from SimCalorimetry.HGCalAssociatorProducers.simClusterToCaloParticleAssociator_cfi import simClusterToCaloParticleAssociator
+from SimCalorimetry.HGCalAssociatorProducers.SimClusterToCaloParticleAssociatorProducer_cfi import SimClusterToCaloParticleAssociatorProducer as SimClusterToCaloParticleAssociator
 
-SimClusterToCaloParticleAssociation = simClusterToCaloParticleAssociator.clone(
+SimClusterToCaloParticleAssociation = SimClusterToCaloParticleAssociator.clone(
     caloParticles = "mix:MergedCaloTruth",
     simClusters = "mix:MergedCaloTruth"
 )

--- a/SimCalorimetry/HGCalAssociatorProducers/python/TSToSimTSAssociation_cfi.py
+++ b/SimCalorimetry/HGCalAssociatorProducers/python/TSToSimTSAssociation_cfi.py
@@ -1,5 +1,5 @@
 import FWCore.ParameterSet.Config as cms
-from SimCalorimetry.HGCalAssociatorProducers.LCToTSAssociator_cfi import layerClusterToCLUE3DTracksterAssociation, layerClusterToTracksterMergeAssociation, layerClusterToSimTracksterAssociation
+from SimCalorimetry.HGCalAssociatorProducers.LCToTSAssociator_cfi import layerClusterToCLUE3DTracksterAssociation, layerClusterToTracksterMergeAssociation, layerClusterToSimTracksterAssociation, layerClusterToSimTracksterFromCPsAssociation
 from SimCalorimetry.HGCalAssociatorProducers.tracksterToSimTracksterAssociatorProducer_cfi import tracksterToSimTracksterAssociatorProducer
 
 tracksterSimTracksterFromCPsAssociationLinking = tracksterToSimTracksterAssociatorProducer.clone(
@@ -7,7 +7,7 @@ tracksterSimTracksterFromCPsAssociationLinking = tracksterToSimTracksterAssociat
     simTracksters = cms.InputTag("ticlSimTracksters", "fromCPs"),
     layerClusters = cms.InputTag("hgcalMergeLayerClusters"),
     tracksterMap = cms.InputTag("layerClusterToTracksterMergeAssociation"),
-    simTracksterMap = cms.InputTag("layerClusterToSimTracksterAssociation")
+    simTracksterMap = cms.InputTag("layerClusterToSimTracksterFromCPsAssociation")
 )
 
 tracksterSimTracksterAssociationLinking = tracksterToSimTracksterAssociatorProducer.clone(
@@ -24,7 +24,7 @@ tracksterSimTracksterFromCPsAssociationPR = tracksterToSimTracksterAssociatorPro
     simTracksters = cms.InputTag("ticlSimTracksters", "fromCPs"),
     layerClusters = cms.InputTag("hgcalMergeLayerClusters"),
     tracksterMap = cms.InputTag("layerClusterToCLUE3DTracksterAssociation"),
-    simTracksterMap = cms.InputTag("layerClusterToSimTracksterAssociation")
+    simTracksterMap = cms.InputTag("layerClusterToSimTracksterFromCPsAssociation")
 )
 
 tracksterSimTracksterAssociationPR = tracksterToSimTracksterAssociatorProducer.clone(

--- a/Validation/Configuration/python/hgcalSimValid_cff.py
+++ b/Validation/Configuration/python/hgcalSimValid_cff.py
@@ -10,7 +10,7 @@ from SimCalorimetry.HGCalAssociatorProducers.SimTauProducer_cfi import *
 
 
 # FP 07/2024: new associators:
-from SimCalorimetry.HGCalAssociatorProducers.LCToTSAssociator_cfi import layerClusterToCLUE3DTracksterAssociation, layerClusterToTracksterMergeAssociation, layerClusterToSimTracksterAssociation
+from SimCalorimetry.HGCalAssociatorProducers.LCToTSAssociator_cfi import layerClusterToCLUE3DTracksterAssociation, layerClusterToTracksterMergeAssociation, layerClusterToSimTracksterAssociation, layerClusterToSimTracksterFromCPsAssociation
 from SimCalorimetry.HGCalAssociatorProducers.HitToTracksterAssociation_cfi import hitToTrackstersAssociationLinking, hitToTrackstersAssociationPR, hitToSimTracksterAssociation, hitToSimTracksterFromCPsAssociation
 from SimCalorimetry.HGCalAssociatorProducers.TSToSimTSAssociationByHits_cfi import tracksterSimTracksterAssociationByHitsLinking, tracksterSimTracksterAssociationByHitsPR
 from SimCalorimetry.HGCalAssociatorProducers.TSToSimTSAssociation_cfi import tracksterSimTracksterFromCPsAssociationLinking, tracksterSimTracksterAssociationLinking, tracksterSimTracksterFromCPsAssociationPR, tracksterSimTracksterAssociationPR
@@ -44,7 +44,7 @@ hgcalAssociators = cms.Task(lcAssocByEnergyScoreProducer, layerClusterCaloPartic
                             SimTauProducer,
                             # FP 07/2024 new associators:
                             layerClusterToCLUE3DTracksterAssociation, layerClusterToTracksterMergeAssociation,
-                            layerClusterToSimTracksterAssociation,
+                            layerClusterToSimTracksterAssociation, layerClusterToSimTracksterFromCPsAssociation,
                             hitToTrackstersAssociationLinking, hitToTrackstersAssociationPR,
                             hitToSimTracksterAssociation, hitToSimTracksterFromCPsAssociation,
                             tracksterSimTracksterAssociationByHitsLinking, tracksterSimTracksterAssociationByHitsPR,

--- a/Validation/HGCalValidation/plugins/HGCalValidator.cc
+++ b/Validation/HGCalValidation/plugins/HGCalValidator.cc
@@ -75,7 +75,7 @@ HGCalValidator::HGCalValidator(const edm::ParameterSet& pset)
       cummatbudinxo_(pset.getParameter<edm::FileInPath>("cummatbudinxo")),
       isTICLv5_(pset.getUntrackedParameter<bool>("isticlv5")),
       hits_label_(pset.getParameter<std::vector<edm::InputTag>>("hits")),
-      scToCpMapToken_(consumes<SimClusterToCaloParticleMap>(pset.getParameter<edm::InputTag>("SimClustersToCaloParticlesMap")))
+      scToCpMapToken_(consumes<SimClusterToCaloParticleMap>(pset.getParameter<edm::InputTag>("simClustersToCaloParticlesMap")))
  {
 
   std::cout << "scToCpMapToken_: " << scToCpMapToken_.index() << " " << scToCpMapToken_.isUninitialized() << std::endl;
@@ -762,7 +762,7 @@ void HGCalValidator::fillDescriptions(edm::ConfigurationDescriptions& descriptio
   desc.add<std::string>("label_TS", "Morphology");
   desc.add<std::string>("label_TSToCPLinking", "TSToCP_linking");
   desc.add<std::string>("label_TSToSTSPR", "TSToSTS_patternRecognition");
-  desc.add<edm::InputTag>("SimClustersToCaloParticlesMap", edm::InputTag("SimClusterToCaloParticleAssociation"));
+  desc.add<edm::InputTag>("simClustersToCaloParticlesMap", edm::InputTag("SimClusterToCaloParticleAssociation","simClusterToCaloParticleMap"));
   desc.add<std::vector<edm::InputTag>>(
       "allTracksterTracksterAssociatorsLabels",
       {


### PR DESCRIPTION
- added the module label `"simClusterToCaloParticleMap"` to the `consumes` to fix the error of the product not found in the Validation
- added the missing `layerClusterToSimTracksterFromCPsAssociation` and use it in the trackster <--> simTrackstersFromCPs associators (previously they were using the `layerClusterToSimTracksterAssociation`)