### PR TITLE
allow multiple collections in makeHGCalValidationPlots.py

### DIFF
--- a/Validation/HGCalValidation/python/hgcalPlots.py
+++ b/Validation/HGCalValidation/python/hgcalPlots.py
@@ -2954,33 +2954,29 @@ hgcalHitCalibPlotter.append("EcalDrivenGsfElectronsFromTrackster_Closest_EoverCP
         purpose=PlotPurpose.Timing, page=hitCalibrationLabel, section=hitCalibrationLabel
         ))
 
-def _build_hgcalTICLCandPlotter(dqm_base):
+def hgcalTICLCandPlotter(labels):
   """Build the TICL candidates plotter for a given HGCalValidator base folder."""
   plotter = Plotter()
 
-  plotter.append('ticlCandidates', [
-      dqm_base + hgcalValidator.ticlCandidates.value(),
-  ], PlotFolder(
-      *_candidatesPlots,
-      loopSubFolders=False,
-      purpose=PlotPurpose.Timing, page="General", section="Candidates"))
+  for label in labels:
+      plotter.append('ticlCandidates', [
+          hgcVal_dqm + label,
+      ], PlotFolder(
+          *_candidatesPlots,
+          loopSubFolders=False,
+          purpose=PlotPurpose.Timing, page="General", section="Candidates"))
 
-  for i in range(6):
-    plotter.append('ticlCandidates', [
-        dqm_base + hgcalValidator.ticlCandidates.value() + "/" + cand_type[i],
-    ], PlotFolder(
-        *_allCandidatesPlots[i],
-        loopSubFolders=False,
-        purpose=PlotPurpose.Timing, page=cand_type[i], section="Candidates"))
+      for i in range(6):
+        plotter.append('ticlCandidates', [
+            hgcVal_dqm + label + "/" + cand_type[i],
+        ], PlotFolder(
+            *_allCandidatesPlots[i],
+            loopSubFolders=False,
+            purpose=PlotPurpose.Timing, page=cand_type[i], section="Candidates"))
 
   return plotter
 
-
-hgcalTICLCandPlotter = _build_hgcalTICLCandPlotter(hgcVal_dqm)
-
-
 def set_hgcVal_dqm(dqm_base):
   """Override the HGCalValidator base folder and rebuild dependent plotters."""
-  global hgcVal_dqm, hgcalTICLCandPlotter
+  global hgcVal_dqm
   hgcVal_dqm = dqm_base
-  hgcalTICLCandPlotter = _build_hgcalTICLCandPlotter(hgcVal_dqm)

--- a/Validation/HGCalValidation/scripts/makeHGCalValidationPlots.py
+++ b/Validation/HGCalValidation/scripts/makeHGCalValidationPlots.py
@@ -211,7 +211,8 @@ def main(opts):
             if not has_candidates:
                 print(f"Skipping candidates for {prefix}: no folder matching 'candidate' found under {dqm_base}")
                 return
-            ticlcand = [hgcalPlots.hgcalTICLCandPlotter]
+            candidate_labels = [n for n in discovered_subdirs if "candidate" in n.lower()]
+            ticlcand = [hgcalPlots.hgcalTICLCandPlotter(candidate_labels)]
             val.doPlots(ticlcand, plotterDrawArgs=drawArgs)
 
         plotDict = {

--- a/Validation/HGCalValidation/scripts/makeHGCalValidationPlots.py
+++ b/Validation/HGCalValidation/scripts/makeHGCalValidationPlots.py
@@ -63,7 +63,11 @@ def main(opts):
     if opts.verbose:
         plotting.verbose = True
 
-    
+    collections = [c.strip() for c in opts.collection.split(",")]
+    for coll in collections:
+        if coll not in collection_choices:
+            raise ValueError(f"Unknown collection '{coll}'. Valid options: {collection_choices}.")
+
     import ROOT
 
     def _discover_subdirs(dqm_file, dqm_base):
@@ -220,9 +224,10 @@ def main(opts):
             candidatesLabel: [plotCand],
         }
 
-        if (opts.collection != allLabel):
-            for task in plotDict[opts.collection]:
-                task()
+        if (allLabel not in collections):
+            for coll in collections:
+                for task in plotDict[coll]:
+                    task()
         else:
             for label in plotDict:
                 if (label == trackstersLabel):
@@ -262,8 +267,8 @@ if __name__ == "__main__":
                         help="Sample name for HTML page generation (default: CMSSW version)")
     parser.add_argument("--html-validation-name", type=str, default=["TICL Validation",""], nargs="+",
                         help="Validation name for HTML page generation (enters to <title> element) (default 'TICL Validation')")
-    parser.add_argument("--collection", choices=collection_choices, default=layerClustersLabel,
-                        help="Choose output plots collections among possible choices")
+    parser.add_argument("--collection", default=layerClustersLabel,
+                        help="Choose output plots collections among possible choices: {collection_choices}")
     parser.add_argument("--extended", action="store_true", default = False,
                         help="Include extended set of plots (e.g. bunch of distributions; default off)")
     parser.add_argument("--jobs", default=0, type=int,


### PR DESCRIPTION
Now `--collection` accepts a comma-separated list of arguments: 
`makeHGCalValidationPlots.py harvest.root --collection tracksters,candidates --ticlv 5`

In addition, the CP index of a simtrackster (SC or CP) is now saved in the dumper, to be able to link all the simtrackstersSC that come from the same CP.